### PR TITLE
Redesign navbar with monochrome styling

### DIFF
--- a/front/src/components/NavBar.jsx
+++ b/front/src/components/NavBar.jsx
@@ -72,18 +72,21 @@ const NavBar = () => {
   return (
     <div>
       <div id="navBar" className="navBar mr-auto">
-        <Navbar bg="light" expand="lg">
-          <img src={logo} alt="logo" />
-          <Link className="nav" to="/">
-            <Navbar.Brand>Distri Pollo</Navbar.Brand>
-          </Link>
-     
-          <Navbar.Toggle id="hamburguesa" aria-controls="basic-navbar-nav" />
-          <Navbar.Collapse id="basic-navbar-nav-light">
-            {/* <Navbar className="mr-auto"> */}
-            <Nav>
+        <Navbar expand="lg" variant="dark" className="nav-shell">
+          <Navbar.Brand as={Link} to="/" className="brand-link">
+            <img src={logo} alt="Distri Pollo" className="brand-logo" />
+            <span className="brand-title">Distri Pollo</span>
+          </Navbar.Brand>
 
-            {payload.role === "ADMIN_ROLE" && (
+          <Navbar.Toggle
+            id="hamburguesa"
+            className="nav-toggler"
+            aria-controls="primary-navbar-nav"
+          />
+          <Navbar.Collapse id="primary-navbar-nav" className="nav-collapse">
+            {/* <Navbar className="mr-auto"> */}
+            <Nav className="nav-links">
+              {payload.role === "ADMIN_ROLE" && (
                 <NavDropdown title="Preventa" id="navbarScrollingDropdown">
                   <NavDropdown.Item
                     href="/comandas"
@@ -395,23 +398,25 @@ const NavBar = () => {
                 </Link>
               )}
             </Nav>
-            {payload.role === "ADMIN_ROLE" && (
-              <Link
-                to="/admin"
-                id="user"
-                className="text-decoration-none text-muted ml-5 mr-3 "
+            <div className="nav-actions">
+              {payload.role === "ADMIN_ROLE" && (
+                <Link
+                  to="/admin"
+                  id="user"
+                  className="text-decoration-none text-muted"
+                >
+                  Administrador
+                </Link>
+              )}
+              <button
+                id="booton"
+                className="btn btn-outline-info"
+                onClick={handleLogin}
               >
-                Administrador
-              </Link>
-            )}
-            <button
-              id="booton"
-              className="btn btn-outline-info"
-              onClick={handleLogin}
-            >
-              {user}
-            </button>
-     
+                {user}
+              </button>
+            </div>
+
           </Navbar.Collapse>
         </Navbar>
       </div>

--- a/front/src/css/navbar.css
+++ b/front/src/css/navbar.css
@@ -1,217 +1,219 @@
-.navBar-toggler {
-  color: #17a288 !important;
-  background-color: white !important;
-}
-.navBar h4 {
-  font-size: 1.75rem;
-  text-align: center;
-
-  background-color: black !important;
-  color: #f1faee !important;
-  font-family: "Quicksand";
-}
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap");
 
 .navBar {
-  /* background-color: black !important; */
-  background-color: #1d3557 !important;
-  color: rgb(163, 159, 159) !important;
-  font-size: 2rem;
-  font-family: "Times New Roman", Times, serif;
-  padding: 1rem;
+  background: linear-gradient(135deg, #050505 0%, #1a1a1a 100%);
+  color: #f5f5f5;
+  font-family: "Poppins", "Segoe UI", sans-serif;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-button #hamburguesa.navBar-toggler.collapsed{
-  background: white !important;
-}
-.nav-link {
-  font-family: "Quicksand";
-  /* background-color: #1d3557 !important; */
-  /* background-color: black !important; */
-  font-size: 1.75rem;
-  display: inline;
-  text-align: center;
-  /* -webkit-margin-start: 2rem; */
-  color: #f1faee !important;
+.nav-shell {
+  width: 100%;
+  background: transparent !important;
+  padding: 0 1.5rem;
 }
 
-#navbarScrollingDropdown {
-  font-family: "Quicksand";
-  /* background-color: black !important; */
-  /* background-color: #1d3557 !important; */
-  font-size: 1.75rem;
-  display: inline;
-  text-align: center;
-  -webkit-margin-start: 1rem;
-  -webkit-margin-end: 1rem;
-  color: #f1faee !important;
+.brand-link {
+  display: flex !important;
+  align-items: center;
+  gap: 0.75rem;
+  color: inherit !important;
+  text-decoration: none;
+  padding: 0.25rem 0;
+}
+
+.brand-logo {
+  height: 3rem;
+  width: auto;
+  object-fit: contain;
+  filter: grayscale(100%);
+}
+
+.brand-title {
+  font-size: 1.35rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.nav-toggler {
+  border-radius: 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  padding: 0.35rem 0.6rem;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.nav-toggler:focus,
+.nav-toggler:hover {
+  border-color: rgba(255, 255, 255, 0.6);
+  background-color: rgba(255, 255, 255, 0.08);
+  outline: none;
+  box-shadow: none;
+}
+
+.nav-toggler .navbar-toggler-icon {
+  filter: invert(1);
+}
+
+.nav-collapse {
+  width: 100%;
+  margin-top: 0.75rem;
+}
+
+@media (min-width: 992px) {
+  .nav-shell {
+    padding: 0 2.5rem;
+  }
+
+  .nav-collapse {
+    margin-top: 0;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.nav-links {
   display: flex;
-  justify-content: center;
-  margin-top: 0.5rem;
+  flex-wrap: wrap;
+  flex: 1 1 auto;
+  width: 100%;
+  gap: 0.5rem;
 }
 
-.dropdown-menu {
-  font-family: "Quicksand";
-  font-size: 1.5rem;
-  /* background-color: black !important; */
-  background-color: #1d3557 !important;
-  color: #f1faee !important;
+@media (min-width: 992px) {
+  .nav-links {
+    gap: 1.5rem;
+    align-items: center;
+  }
 }
 
-.dropdown-item {
-  font-family: "Quicksand";
-  font-size: 1.5rem;
-  /* background-color: black !important; */
-  background-color: #1d3557 !important;
-  color: #f1faee !important;
+@media (max-width: 991.98px) {
+  .nav-links {
+    flex-direction: column;
+  }
 }
 
-.nav-link1 {
-  font-family: "Quicksand";
-  color: #e63946 !important;
-  margin-bottom: 10px;
-  font-size: 1.75rem;
-  display: inline;
-  text-align: center;
-  /* -webkit-margin-start: 2rem; */
-  /* margin-top: 0rem; */
+.nav-links .nav-link,
+.nav-links .dropdown-toggle {
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: rgba(245, 245, 245, 0.85) !important;
+  padding: 0.5rem 0;
+  margin: 0 !important;
+  transition: color 0.2s ease, opacity 0.2s ease;
 }
 
+.nav-links .nav-link:hover,
+.nav-links .nav-link:focus,
+.nav-links .dropdown-toggle:hover,
+.nav-links .dropdown-toggle:focus {
+  color: #ffffff !important;
+  text-decoration: none;
+}
+
+.nav-links .dropdown-toggle::after {
+  margin-left: 0.35rem;
+}
+
+.navBar .dropdown-menu {
+  background-color: #1f1f1f;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.75rem;
+  padding: 0.5rem 0;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+}
+
+.navBar .dropdown-item {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: rgba(245, 245, 245, 0.8) !important;
+  padding: 0.45rem 1.5rem;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.navBar .dropdown-item:hover,
+.navBar .dropdown-item:focus {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  color: #ffffff !important;
+}
+
+.nav-link1,
+.nav-link2,
 .nav-link3 {
-  font-family: "Quicksand";
-  color: #e63946 !important;
-  margin-bottom: 10px;
-  font-size: 1.75rem;
-  display: inline;
-  text-align: center;
-  /* -webkit-margin-start: 2rem; */
-  /* margin-top: 0rem; */
+  color: rgba(245, 245, 245, 0.85) !important;
 }
 
-.nav-link2 {
-  font-family: "Quicksand";
-  color: rgb(18, 204, 18) !important;
-  margin-bottom: 10px;
-  font-size: 1.75rem;
-  display: inline;
-  text-align: center;
-  /* -webkit-margin-start: 2rem; */
-
+.nav-actions {
   display: flex;
-  justify-content: center;
-}
-
-#navBar nav {
-  background-color: #1d3557 !important;
-  /* background-color: black !important; */
-  font-size: 1.75rem;
-  display: flex;
-  justify-content: center;
-  color: rgb(163, 159, 159) !important;
-}
-
-.navBar img {
-  height: 10rem;
-  padding: 1rem;
-  display: flex;
-  justify-content: center;
-  color: #f1faee !important;
-}
-
-.navBar span {
-  background-color: #1d3557 !important;
-  /* background-color: black !important; */
-  font-size: 2.2rem;
-  color: #f1faee !important;
-  font-family: "Times New Roman", Times, serif;
-}
-
-#booton {
-  font-family: "Quicksand";
-  font-size: 1.75rem;
+  align-items: center;
+  gap: 1rem;
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 #user {
-  font-family: "Quicksand";
-  font-size: 1.75rem;
-  color: #17a2bb !important;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: rgba(245, 245, 245, 0.7) !important;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+#user:hover {
+  color: #ffffff !important;
+  text-decoration: none;
+}
+
+#booton {
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.45rem 1.6rem;
+  border-radius: 999px;
+  background: transparent;
+  color: #f5f5f5;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+#booton:hover,
+#booton:focus {
+  background-color: #f5f5f5;
+  color: #111111;
+  border-color: #f5f5f5;
+  outline: none;
+  box-shadow: none;
 }
 
 .nav-link4 img {
-  height: 45px;
+  height: 2.5rem;
+  filter: grayscale(100%);
 }
 
-@media (max-width: 768px) {
-  .navBar img {
-    display: flex;
+@media (max-width: 991.98px) {
+  .nav-shell {
+    padding: 0 1rem;
+  }
+
+  .nav-collapse {
+    background-color: #111111;
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+  }
+
+  .nav-links {
+    gap: 0.25rem;
+  }
+
+  .nav-actions {
+    width: 100%;
     justify-content: flex-start;
-    align-self: flex-end;
-    justify-content: right;
-    padding: 1rem;
+    margin-top: 1rem;
   }
-}
 
-@media (max-width: 768px) {
-  .navBar img {
-    display: flex;
-    justify-content: flex-start;
-    align-self: flex-end;
-    justify-content: right;
-    padding: 1rem;
-  }
-}
-
-@media (max-width: 768px) {
-  .nav {
-    display: flex;
-    justify-content: flex-start;
-  }
-}
-
-@media (max-width: 768px) {
-  .navBar nav {
-    font-size: 1rem;
-    padding: 0.5rem;
-  }
-}
-
-@media (max-width: 768px) {
-  .nav-link4 img {
-    display: flex;
-    justify-content: center;
-    display: none;
-  }
-}
-
-@media (max-width: 768px) {
-  #user {
-    /* display: none; */
-  }
-}
-
-@media (max-width: 1024px) {
-  #user {
-    display: none;
-  }
-}
-
-@media (max-width: 768px) {
   #booton {
     width: 100%;
-    height: 100%;
-    margin-top: 10px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #17a288;
+    text-align: center;
   }
 }
-/* 
-  @media (max-width: 768px) {
-    .navbar-toggler-icon span {
-      margin-left: 50%;
-      margin-top: 10px;
-      transform: translateX(130%);
-      background-color: red !important;
-      color: red !important;
-    }
-  } */


### PR DESCRIPTION
## Summary
- redesign the navigation bar markup to support a monochrome brand presentation
- refresh navbar typography and layout for a more contemporary distribution
- replace the navbar stylesheet with grayscale-focused styles, including responsive refinements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df05b8139c832391df6dde6fa47799