### PR TITLE
Update navbar styling to grayscale palette

### DIFF
--- a/front/src/css/navbar.css
+++ b/front/src/css/navbar.css
@@ -1,27 +1,35 @@
 .navBar-toggler {
-  color: #17a288 !important;
-  background-color: white !important;
+  color: #f5f5f5 !important;
+  background-color: #121212 !important;
+  border: 1px solid #3a3a3a !important;
 }
 .navBar h4 {
   font-size: 1.75rem;
   text-align: center;
 
-  background-color: black !important;
-  color: #f1faee !important;
+  background-color: #121212 !important;
+  color: #f5f5f5 !important;
   font-family: "Quicksand";
 }
 
 .navBar {
   /* background-color: black !important; */
-  background-color: #1d3557 !important;
-  color: rgb(163, 159, 159) !important;
+  background-color: #121212 !important;
+  color: #f5f5f5 !important;
   font-size: 2rem;
   font-family: "Times New Roman", Times, serif;
   padding: 1rem;
 }
 
+.navBar-toggler:hover,
+.navBar-toggler:focus {
+  color: #e0e0e0 !important;
+  background-color: #1b1b1b !important;
+  border-color: #4a4a4a !important;
+  outline: none;
+}
 button #hamburguesa.navBar-toggler.collapsed{
-  background: white !important;
+  background: #1b1b1b !important;
 }
 .nav-link {
   font-family: "Quicksand";
@@ -31,7 +39,13 @@ button #hamburguesa.navBar-toggler.collapsed{
   display: inline;
   text-align: center;
   /* -webkit-margin-start: 2rem; */
-  color: #f1faee !important;
+  color: #f5f5f5 !important;
+}
+.nav-link:hover,
+.nav-link:focus {
+  color: #e0e0e0 !important;
+  background-color: #2a2a2a !important;
+  outline: none;
 }
 
 #navbarScrollingDropdown {
@@ -43,7 +57,7 @@ button #hamburguesa.navBar-toggler.collapsed{
   text-align: center;
   -webkit-margin-start: 1rem;
   -webkit-margin-end: 1rem;
-  color: #f1faee !important;
+  color: #f5f5f5 !important;
   display: flex;
   justify-content: center;
   margin-top: 0.5rem;
@@ -53,32 +67,44 @@ button #hamburguesa.navBar-toggler.collapsed{
   font-family: "Quicksand";
   font-size: 1.5rem;
   /* background-color: black !important; */
-  background-color: #1d3557 !important;
-  color: #f1faee !important;
+  background-color: #1b1b1b !important;
+  color: #f5f5f5 !important;
+  border: 1px solid #3a3a3a !important;
 }
 
 .dropdown-item {
   font-family: "Quicksand";
   font-size: 1.5rem;
   /* background-color: black !important; */
-  background-color: #1d3557 !important;
-  color: #f1faee !important;
+  background-color: #1b1b1b !important;
+  color: #f5f5f5 !important;
+}
+.dropdown-item:hover,
+.dropdown-item:focus {
+  color: #e0e0e0 !important;
+  background-color: #2a2a2a !important;
 }
 
 .nav-link1 {
   font-family: "Quicksand";
-  color: #e63946 !important;
+  color: #f5f5f5 !important;
   margin-bottom: 10px;
   font-size: 1.75rem;
   display: inline;
   text-align: center;
   /* -webkit-margin-start: 2rem; */
   /* margin-top: 0rem; */
+}
+.nav-link1:hover,
+.nav-link1:focus {
+  color: #e0e0e0 !important;
+  background-color: #2a2a2a !important;
+  outline: none;
 }
 
 .nav-link3 {
   font-family: "Quicksand";
-  color: #e63946 !important;
+  color: #f5f5f5 !important;
   margin-bottom: 10px;
   font-size: 1.75rem;
   display: inline;
@@ -86,10 +112,16 @@ button #hamburguesa.navBar-toggler.collapsed{
   /* -webkit-margin-start: 2rem; */
   /* margin-top: 0rem; */
 }
+.nav-link3:hover,
+.nav-link3:focus {
+  color: #e0e0e0 !important;
+  background-color: #2a2a2a !important;
+  outline: none;
+}
 
 .nav-link2 {
   font-family: "Quicksand";
-  color: rgb(18, 204, 18) !important;
+  color: #f5f5f5 !important;
   margin-bottom: 10px;
   font-size: 1.75rem;
   display: inline;
@@ -99,14 +131,20 @@ button #hamburguesa.navBar-toggler.collapsed{
   display: flex;
   justify-content: center;
 }
+.nav-link2:hover,
+.nav-link2:focus {
+  color: #e0e0e0 !important;
+  background-color: #2a2a2a !important;
+  outline: none;
+}
 
 #navBar nav {
-  background-color: #1d3557 !important;
+  background-color: #121212 !important;
   /* background-color: black !important; */
   font-size: 1.75rem;
   display: flex;
   justify-content: center;
-  color: rgb(163, 159, 159) !important;
+  color: #f5f5f5 !important;
 }
 
 .navBar img {
@@ -114,26 +152,40 @@ button #hamburguesa.navBar-toggler.collapsed{
   padding: 1rem;
   display: flex;
   justify-content: center;
-  color: #f1faee !important;
+  color: #f5f5f5 !important;
 }
 
 .navBar span {
-  background-color: #1d3557 !important;
+  background-color: #121212 !important;
   /* background-color: black !important; */
   font-size: 2.2rem;
-  color: #f1faee !important;
+  color: #f5f5f5 !important;
   font-family: "Times New Roman", Times, serif;
 }
 
 #booton {
   font-family: "Quicksand";
   font-size: 1.75rem;
+  color: #f5f5f5 !important;
+  background-color: #1b1b1b !important;
+  border: 1px solid #3a3a3a !important;
+}
+#booton:hover,
+#booton:focus {
+  color: #e0e0e0 !important;
+  background-color: #2a2a2a !important;
+  border-color: #4a4a4a !important;
+  outline: none;
 }
 
 #user {
   font-family: "Quicksand";
   font-size: 1.75rem;
-  color: #17a2bb !important;
+  color: #e0e0e0 !important;
+}
+#user:focus {
+  outline: 2px solid #4a4a4a;
+  outline-offset: 2px;
 }
 
 .nav-link4 img {
@@ -202,7 +254,7 @@ button #hamburguesa.navBar-toggler.collapsed{
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #17a288;
+    color: #e0e0e0;
   }
 }
 /* 


### PR DESCRIPTION
## Summary
- restyle the navbar, dropdown, and user controls with a grayscale palette
- add hover and focus states to navigation links and dropdown items for better contrast and accessibility

## Testing
- npm install --legacy-peer-deps
- NODE_OPTIONS=--openssl-legacy-provider npm start

------
https://chatgpt.com/codex/tasks/task_e_68df08fdb414832385b0299558da83f2