### PR TITLE
Update navbar typography

### DIFF
--- a/front/public/index.html
+++ b/front/public/index.html
@@ -15,8 +15,12 @@
   <link rel="stylesheet" href="%PUBLIC_URL%/plugins/select2/css/select2.min.css" />
   <link rel="stylesheet" href="%PUBLIC_URL%/plugins/select2-bootstrap4-theme/select2-bootstrap4.min.css" />
 
-  <link rel="preconnect" href="https://fonts.gstatic.com" />
-  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@600&display=swap" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
   <!-- <script src="https://cdn.fromdoppler.com/formgenerator/latest/vendor.js?47288510"></script>
     <link rel="stylesheet" href="https://cdn.fromdoppler.com/formgenerator/latest/styles.css?47288510" /> -->
   <title>Distripollo App</title>

--- a/front/src/css/navbar.css
+++ b/front/src/css/navbar.css
@@ -4,20 +4,23 @@
   border: 1px solid #3a3a3a !important;
 }
 .navBar h4 {
-  font-size: 1.75rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  font-size: 1.5rem;
+  font-weight: 600;
   text-align: center;
 
   background-color: #121212 !important;
   color: #f5f5f5 !important;
-  font-family: "Quicksand";
 }
 
 .navBar {
   /* background-color: black !important; */
   background-color: #121212 !important;
   color: #f5f5f5 !important;
-  font-size: 2rem;
-  font-family: "Times New Roman", Times, serif;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
   padding: 1rem;
 }
 
@@ -32,12 +35,15 @@ button #hamburguesa.navBar-toggler.collapsed{
   background: #1b1b1b !important;
 }
 .nav-link {
-  font-family: "Quicksand";
+  font-family: "Inter", "Segoe UI", sans-serif;
   /* background-color: #1d3557 !important; */
   /* background-color: black !important; */
-  font-size: 1.75rem;
+  font-size: 1.125rem;
+  font-weight: 500;
+  letter-spacing: 0.015em;
   display: inline;
   text-align: center;
+  padding: 0.5rem 0.75rem;
   /* -webkit-margin-start: 2rem; */
   color: #f5f5f5 !important;
 }
@@ -49,10 +55,12 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 
 #navbarScrollingDropdown {
-  font-family: "Quicksand";
+  font-family: "Inter", "Segoe UI", sans-serif;
   /* background-color: black !important; */
   /* background-color: #1d3557 !important; */
-  font-size: 1.75rem;
+  font-size: 1.125rem;
+  font-weight: 500;
+  letter-spacing: 0.015em;
   display: inline;
   text-align: center;
   -webkit-margin-start: 1rem;
@@ -64,8 +72,10 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 
 .dropdown-menu {
-  font-family: "Quicksand";
-  font-size: 1.5rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
   /* background-color: black !important; */
   background-color: #1b1b1b !important;
   color: #f5f5f5 !important;
@@ -73,11 +83,14 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 
 .dropdown-item {
-  font-family: "Quicksand";
-  font-size: 1.5rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  font-size: 0.95rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
   /* background-color: black !important; */
   background-color: #1b1b1b !important;
   color: #f5f5f5 !important;
+  padding: 0.45rem 1.25rem;
 }
 .dropdown-item:hover,
 .dropdown-item:focus {
@@ -86,12 +99,15 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 
 .nav-link1 {
-  font-family: "Quicksand";
+  font-family: "Inter", "Segoe UI", sans-serif;
   color: #f5f5f5 !important;
   margin-bottom: 10px;
-  font-size: 1.75rem;
+  font-size: 1.125rem;
+  font-weight: 500;
+  letter-spacing: 0.015em;
   display: inline;
   text-align: center;
+  padding: 0.5rem 0.75rem;
   /* -webkit-margin-start: 2rem; */
   /* margin-top: 0rem; */
 }
@@ -103,12 +119,15 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 
 .nav-link3 {
-  font-family: "Quicksand";
+  font-family: "Inter", "Segoe UI", sans-serif;
   color: #f5f5f5 !important;
   margin-bottom: 10px;
-  font-size: 1.75rem;
+  font-size: 1.125rem;
+  font-weight: 500;
+  letter-spacing: 0.015em;
   display: inline;
   text-align: center;
+  padding: 0.5rem 0.75rem;
   /* -webkit-margin-start: 2rem; */
   /* margin-top: 0rem; */
 }
@@ -120,12 +139,15 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 
 .nav-link2 {
-  font-family: "Quicksand";
+  font-family: "Inter", "Segoe UI", sans-serif;
   color: #f5f5f5 !important;
   margin-bottom: 10px;
-  font-size: 1.75rem;
+  font-size: 1.125rem;
+  font-weight: 500;
+  letter-spacing: 0.015em;
   display: inline;
   text-align: center;
+  padding: 0.5rem 0.75rem;
   /* -webkit-margin-start: 2rem; */
 
   display: flex;
@@ -141,7 +163,10 @@ button #hamburguesa.navBar-toggler.collapsed{
 #navBar nav {
   background-color: #121212 !important;
   /* background-color: black !important; */
-  font-size: 1.75rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  font-size: 1.125rem;
+  font-weight: 600;
+  letter-spacing: 0.015em;
   display: flex;
   justify-content: center;
   color: #f5f5f5 !important;
@@ -158,14 +183,17 @@ button #hamburguesa.navBar-toggler.collapsed{
 .navBar span {
   background-color: #121212 !important;
   /* background-color: black !important; */
-  font-size: 2.2rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  font-size: 1.75rem;
+  font-weight: 600;
   color: #f5f5f5 !important;
-  font-family: "Times New Roman", Times, serif;
 }
 
 #booton {
-  font-family: "Quicksand";
-  font-size: 1.75rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  font-size: 1.125rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
   color: #f5f5f5 !important;
   background-color: #1b1b1b !important;
   border: 1px solid #3a3a3a !important;
@@ -179,8 +207,10 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 
 #user {
-  font-family: "Quicksand";
-  font-size: 1.75rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
   color: #e0e0e0 !important;
 }
 #user:focus {


### PR DESCRIPTION
## Summary
- add Google Fonts preload links for Inter in the public index page
- refresh navbar typography to use Inter with refined sizing, weights, and spacing across links, dropdowns, and buttons

## Testing
- npm install --legacy-peer-deps
- npm start *(fails: webpack uses legacy OpenSSL algorithms under Node 20, producing ERR_OSSL_EVP_UNSUPPORTED)*

------
https://chatgpt.com/codex/tasks/task_e_68df0b39b7d08323b347f2be5cc1df30