### PR TITLE
feat(front): redesign footer with alt theme

### DIFF
--- a/front/src/components/Footer.jsx
+++ b/front/src/components/Footer.jsx
@@ -5,55 +5,57 @@ import logo from "../images/logocode.png";
 
 const Footer = () => {
   return (
-    <footer id="footer">
+    <footer id="footer" className="alt">
       <div className="container">
-        <div className="row">
-          <div className="col-lg-4 col-xs-12 col-md-12">
-            <div className="row">
-              <div className="col-lg-12 col-md-12 visible-md visible-lg copyright">
-                <img src={logo} alt="logo" />
-                <p>
-                  © Copyright 2021 <strong> Distripollo </strong>
-                </p>
-              </div>
-              <div className="col-lg-12 col-md-12 visible-md visible-lg copyright">
-                <p>
-                  <strong> by Abeto Tech - División Web </strong>
-                </p>
-              </div>
+        <div className="row g-4">
+          <div className="col-lg-4 col-md-6 footer-section">
+            <div className="footer-card">
+              <img src={logo} alt="Distripollo logo" />
+              <p>
+                Soluciones integrales para tu negocio gastronómico, con
+                distribución confiable y soporte cercano en cada pedido.
+              </p>
+              <p className="footer-meta mb-0">
+                © Copyright {new Date().getFullYear()} <strong>Distripollo</strong>
+              </p>
+              <p className="footer-meta">
+                Diseñado por <strong>Abeto Tech - División Web</strong>
+              </p>
             </div>
           </div>
-          <div className="col-4">
-            {/* <a title="Whatsapp" 
-                        href="https://wa.link/0zbip1"
-                        target="_blank">
-                        <img className="imag1" 
-                            src="https://play-lh.googleusercontent.com/bYtqbOcTYOlgc6gqZ2rwb8lptHuwlNE75zYJu6Bn076-hTmvd96HH-6v7S0YUAAJXoJN" 
-                            alt="Whatsapp" 
-                            width="100" 
-                            height="100"
-                        />
-                    </a> */}
-            {/* <h3>CONTACTANOS</h3> */}
+
+          <div className="col-lg-4 col-md-6 footer-section">
+            <div className="footer-card">
+              <h3 className="footer-heading">Enlaces rápidos</h3>
+              <ul className="footer-links">
+                <li>
+                  <a href="/#productos">Productos</a>
+                </li>
+                <li>
+                  <a href="/#servicios">Servicios</a>
+                </li>
+                <li>
+                  <a href="/#nosotros">Nosotros</a>
+                </li>
+                <li>
+                  <a href="/#contacto">Contacto</a>
+                </li>
+              </ul>
+            </div>
           </div>
 
-          <div id="contacto" className="col-lg-4 col-xs-12 col-md-12">
-            <div className="row">
-              <div className="col-md-12 hidden-xs hidden-sm ">
-                <p className="contact">
-                  <strong>CONTACTO</strong>
-                </p>
-                <p className="description-contact">
-                  Por consultas comuníquese con nosotros:
-                </p>
-                <p className="description-contact">
-                  Lun a Sab de 9 a 18 Hs - Tel +3816298096
-                </p>
-                {/* <p className="description-contact">Cel +5493816900030 +5493814909195</p> */}
-                <p className="description-contact">
-                  Domicilio: Eudoro Araoz 933
-                </p>
-              </div>
+          <div className="col-lg-4 col-md-12 footer-section">
+            <div className="footer-card">
+              <h3 className="footer-heading">Atención al cliente</h3>
+              <p>
+                Para consultas y pedidos comuníquese con nosotros de lunes a
+                sábado de 9 a 18 h.
+              </p>
+              <p className="mb-1">Teléfono: +54 381 629 8096</p>
+              <p className="mb-3">Domicilio: Eudoro Araoz 933</p>
+              <a className="btn footer-cta" href="mailto:contacto@distripollo.com">
+                Escríbenos por correo
+              </a>
             </div>
           </div>
         </div>

--- a/front/src/css/footer.css
+++ b/front/src/css/footer.css
@@ -7,39 +7,155 @@
   font-size: 1rem !important;
 }
 
-#footer p {
-  font-size: 1.2rem;
+#footer.alt {
+  background: linear-gradient(135deg, #1a1a1a, #2f2f2f);
+  color: #f5f5f5 !important;
+  padding: 3rem 0;
+  font-family: "Quicksand", "Times New Roman", Times, serif;
+  text-align: left;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 -10px 30px rgba(0, 0, 0, 0.35);
 }
 
-#footer a {
-  color: #f1faee !important;
+#footer.alt .footer-section {
+  border-left: 1px solid #3a3a3a;
+  padding-left: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
 }
 
-#footer img {
-  height: 6rem;
-  padding: 1rem;
+#footer.alt .footer-section:first-of-type {
+  border-left: none;
+  padding-left: 0;
 }
 
-#footer .imag1 {
-  margin-top: 15px;
-  height: 6rem;
-  width: 6rem;
+#footer.alt .footer-card {
+  width: 100%;
+  background: rgba(26, 26, 26, 0.6);
+  border: 1px solid #3a3a3a;
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
-/*footer centrado*/
-@media (max-width: 1024px) {
-  #contacto {
-    text-align: center !important;
+
+#footer.alt .footer-heading {
+  font-size: 1.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #e0e0e0;
+  border-bottom: 1px solid #3a3a3a;
+  padding-bottom: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+#footer.alt p,
+#footer.alt li,
+#footer.alt a {
+  font-size: 1.1rem;
+  color: #f5f5f5 !important;
+  line-height: 1.75rem;
+}
+
+#footer.alt img {
+  max-width: 160px;
+  height: auto;
+  padding: 0;
+  filter: drop-shadow(0 10px 20px rgba(0, 0, 0, 0.5));
+}
+
+#footer.alt .footer-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+#footer.alt a {
+  text-decoration: none;
+  transition: color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#footer.alt a:hover,
+#footer.alt a:focus {
+  color: #e0e0e0 !important;
+  background-color: #2a2a2a !important;
+  box-shadow: 0 0 0 2px rgba(224, 224, 224, 0.1);
+  outline: none;
+}
+
+#footer.alt .btn.footer-cta {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border: 1px solid #3a3a3a;
+  background: rgba(42, 42, 42, 0.75);
+  padding: 0.6rem 1.5rem;
+}
+
+#footer.alt .btn.footer-cta:hover,
+#footer.alt .btn.footer-cta:focus {
+  color: #e0e0e0 !important;
+  background-color: #2a2a2a !important;
+  border-color: #4a4a4a;
+}
+
+#footer.alt .footer-meta {
+  font-size: 0.95rem;
+  color: #cfcfcf;
+}
+
+@media (max-width: 991px) {
+  #footer.alt {
+    padding: 2.5rem 0;
+  }
+
+  #footer.alt .footer-section {
+    margin-bottom: 2rem;
+  }
+
+  #footer.alt .footer-card {
+    height: 100%;
   }
 }
 
-@media (min-width: 1024px) {
-  #contacto {
-    text-align: right !important;
+@media (max-width: 768px) {
+  #footer.alt {
+    text-align: center;
   }
-}
 
-@media (max-width: 1024px) {
-  #footer .imag1 {
-    margin-left: 120px !important;
+  #footer.alt .footer-section {
+    border-left: none;
+    border-top: 1px solid #3a3a3a;
+    padding-left: 0;
+    padding-top: 2rem;
+    margin-top: 2rem;
+    justify-content: center;
+  }
+
+  #footer.alt .footer-section:first-of-type {
+    border-top: none;
+    margin-top: 0;
+    padding-top: 0;
+  }
+
+  #footer.alt .footer-card {
+    align-items: center;
+    text-align: center;
+    padding: 1.75rem;
+  }
+
+  #footer.alt .footer-links {
+    align-items: center;
   }
 }


### PR DESCRIPTION
## Summary
- add an alternate footer skin with a dark gradient, navbar typography, and responsive separators
- rework the footer component to surface quick links, contact details, and accessible hover states using the new classes

## Testing
- NODE_OPTIONS=--openssl-legacy-provider HOST=0.0.0.0 PORT=3000 npm start *(lint warnings in unrelated legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb8268c0883238dca7bb5e578baaa