### PR TITLE
Fix navbar toggler styling for mobile palette

### DIFF
--- a/front/src/css/navbar.css
+++ b/front/src/css/navbar.css
@@ -1,4 +1,4 @@
-.navBar-toggler {
+.navbar-toggler {
   color: #f5f5f5 !important;
   background-color: #121212 !important;
   border: 1px solid #3a3a3a !important;
@@ -21,15 +21,25 @@
   padding: 1rem;
 }
 
-.navBar-toggler:hover,
-.navBar-toggler:focus {
+.navbar-toggler:hover,
+.navbar-toggler:focus {
   color: #e0e0e0 !important;
   background-color: #1b1b1b !important;
   border-color: #4a4a4a !important;
   outline: none;
 }
-button #hamburguesa.navBar-toggler.collapsed{
+.navbar-toggler.collapsed {
   background: #1b1b1b !important;
+}
+
+.navbar-toggler:active {
+  color: #e0e0e0 !important;
+  background-color: #2a2a2a !important;
+  border-color: #5a5a5a !important;
+}
+
+.navbar-toggler-icon {
+  filter: invert(1);
 }
 .nav-link {
   font-family: "Quicksand";


### PR DESCRIPTION
## Summary
- update navbar toggler selectors to match Bootstrap markup so custom colors apply
- extend toggler state styling and icon filter to maintain dark palette contrast

## Testing
- `npm install` *(fails: dependency conflict between react@17.0.2 and react-datalist-input@3.0.6)*

------
https://chatgpt.com/codex/tasks/task_e_68dfbc7b66c88323a790481be2dbfdb6