### PR TITLE
feat: refresh navigation gradient and typography

### DIFF
--- a/front/src/components/NavBar.jsx
+++ b/front/src/components/NavBar.jsx
@@ -71,8 +71,8 @@ const NavBar = () => {
 
   return (
     <div>
-      <div id="navBar" className="navBar mr-auto">
-        <Navbar bg="light" expand="lg">
+      <div id="navBar" className="navBar__container mr-auto">
+        <Navbar expand="lg" className="navBar navBar--gradient">
           <img src={logo} alt="logo" />
           <Link className="nav" to="/">
             <Navbar.Brand>Distri Pollo</Navbar.Brand>

--- a/front/src/css/footer.css
+++ b/front/src/css/footer.css
@@ -1,9 +1,13 @@
+:root {
+  --footer-gradient: linear-gradient(135deg, #f5f5f5 0%, #d9d9d9 50%, #bcbcbc 100%);
+}
+
 #footer {
-  background-color: #1d3557 !important;
+  background: var(--footer-gradient);
   min-height: 5rem;
   padding: 1rem;
   text-align: center;
-  color: #f1faee !important;
+  color: #1f2933 !important;
   font-size: 1rem !important;
 }
 
@@ -12,7 +16,7 @@
 }
 
 #footer a {
-  color: #f1faee !important;
+  color: #0f172a !important;
 }
 
 #footer img {

--- a/front/src/css/navbar.css
+++ b/front/src/css/navbar.css
@@ -1,95 +1,125 @@
-.navBar-toggler {
-  color: #f5f5f5 !important;
-  background-color: #121212 !important;
-  border: 1px solid #3a3a3a !important;
-}
-.navBar h4 {
-  font-size: 1.75rem;
-  text-align: center;
-
-  background-color: #121212 !important;
-  color: #f5f5f5 !important;
-  font-family: "Quicksand";
+.navBar__container {
+  padding: 0 1rem;
 }
 
 .navBar {
-  /* background-color: black !important; */
-  background-color: #121212 !important;
-  color: #f5f5f5 !important;
+  background: var(
+    --footer-gradient,
+    linear-gradient(135deg, #f5f5f5 0%, #d9d9d9 50%, #bcbcbc 100%)
+  ) !important;
+  color: #1f2933 !important;
   font-size: 2rem;
-  font-family: "Times New Roman", Times, serif;
+  font-family: "Poppins", sans-serif;
+  font-weight: 500;
   padding: 1rem;
 }
 
-.navBar-toggler:hover,
-.navBar-toggler:focus {
-  color: #e0e0e0 !important;
-  background-color: #1b1b1b !important;
-  border-color: #4a4a4a !important;
-  outline: none;
+.navBar--gradient {
+  background: transparent;
+  border-radius: 1.5rem;
+  box-shadow: 0 10px 30px rgba(31, 41, 51, 0.1);
+  overflow: hidden;
 }
-button #hamburguesa.navBar-toggler.collapsed{
-  background: #1b1b1b !important;
-}
-.nav-link {
-  font-family: "Quicksand";
-  /* background-color: #1d3557 !important; */
-  /* background-color: black !important; */
-  font-size: 1.75rem;
-  display: inline;
+
+.navBar h4 {
+  font-size: 1.8rem;
   text-align: center;
-  /* -webkit-margin-start: 2rem; */
-  color: #f5f5f5 !important;
+  color: #1f2933 !important;
+  font-weight: 600;
+  background: transparent;
+  font-family: "Poppins", sans-serif;
 }
-.nav-link:hover,
-.nav-link:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+
+.navBar .navbar-brand {
+  font-family: "Poppins", sans-serif;
+  font-weight: 600;
+  font-size: 2.2rem;
+  color: #0f172a !important;
+  letter-spacing: 0.05em;
+}
+
+.navBar .navbar-brand:hover,
+.navBar .navbar-brand:focus {
+  color: #0b1120 !important;
+}
+
+#hamburguesa.navbar-toggler {
+  color: #1f2933;
+  background: rgba(255, 255, 255, 0.4);
+  border: 1px solid rgba(31, 41, 51, 0.25);
+  border-radius: 0.75rem;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease,
+    border-color 0.3s ease, color 0.3s ease;
+}
+
+#hamburguesa.navbar-toggler:hover,
+#hamburguesa.navbar-toggler:focus {
+  color: #0f172a;
+  background: rgba(255, 255, 255, 0.7);
+  border-color: rgba(31, 41, 51, 0.35);
+  box-shadow: 0 6px 18px rgba(31, 41, 51, 0.2);
   outline: none;
 }
 
-#navbarScrollingDropdown {
-  font-family: "Quicksand";
-  /* background-color: black !important; */
-  /* background-color: #1d3557 !important; */
-  font-size: 1.75rem;
+.nav-link {
+  font-family: "Poppins", sans-serif;
+  font-size: 1.6rem;
+  font-weight: 500;
   display: inline;
+  text-align: center;
+  color: #1f2933 !important;
+  transition: color 0.3s ease, box-shadow 0.3s ease;
+  border-radius: 0.75rem;
+  padding: 0.6rem 1rem;
+}
+.nav-link:hover,
+.nav-link:focus {
+  color: #0f172a !important;
+  box-shadow: 0 8px 18px rgba(31, 41, 51, 0.15);
+  outline: none;
+  background: rgba(255, 255, 255, 0.6);
+}
+
+#navbarScrollingDropdown {
+  font-family: "Poppins", sans-serif;
+  font-size: 1.6rem;
+  font-weight: 500;
+  display: inline-flex;
   text-align: center;
   -webkit-margin-start: 1rem;
   -webkit-margin-end: 1rem;
-  color: #f5f5f5 !important;
-  display: flex;
+  color: #1f2933 !important;
   justify-content: center;
   margin-top: 0.5rem;
 }
 
 .dropdown-menu {
-  font-family: "Quicksand";
-  font-size: 1.5rem;
-  /* background-color: black !important; */
-  background-color: #1b1b1b !important;
-  color: #f5f5f5 !important;
-  border: 1px solid #3a3a3a !important;
+  font-family: "Poppins", sans-serif;
+  font-size: 1.4rem;
+  background-color: rgba(255, 255, 255, 0.92) !important;
+  color: #1f2933 !important;
+  border: 1px solid rgba(31, 41, 51, 0.2) !important;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.15);
 }
 
 .dropdown-item {
-  font-family: "Quicksand";
-  font-size: 1.5rem;
-  /* background-color: black !important; */
-  background-color: #1b1b1b !important;
-  color: #f5f5f5 !important;
+  font-family: "Poppins", sans-serif;
+  font-size: 1.4rem;
+  background: transparent;
+  color: #1f2933 !important;
+  border-radius: 0.75rem;
 }
 .dropdown-item:hover,
 .dropdown-item:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: #0f172a !important;
+  background-color: rgba(226, 232, 240, 0.7) !important;
 }
 
 .nav-link1 {
-  font-family: "Quicksand";
-  color: #f5f5f5 !important;
+  font-family: "Poppins", sans-serif;
+  color: #1f2933 !important;
   margin-bottom: 10px;
-  font-size: 1.75rem;
+  font-size: 1.6rem;
   display: inline;
   text-align: center;
   /* -webkit-margin-start: 2rem; */
@@ -97,16 +127,16 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 .nav-link1:hover,
 .nav-link1:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: #0f172a !important;
+  background-color: rgba(226, 232, 240, 0.7) !important;
   outline: none;
 }
 
 .nav-link3 {
-  font-family: "Quicksand";
-  color: #f5f5f5 !important;
+  font-family: "Poppins", sans-serif;
+  color: #1f2933 !important;
   margin-bottom: 10px;
-  font-size: 1.75rem;
+  font-size: 1.6rem;
   display: inline;
   text-align: center;
   /* -webkit-margin-start: 2rem; */
@@ -114,16 +144,16 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 .nav-link3:hover,
 .nav-link3:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: #0f172a !important;
+  background-color: rgba(226, 232, 240, 0.7) !important;
   outline: none;
 }
 
 .nav-link2 {
-  font-family: "Quicksand";
-  color: #f5f5f5 !important;
+  font-family: "Poppins", sans-serif;
+  color: #1f2933 !important;
   margin-bottom: 10px;
-  font-size: 1.75rem;
+  font-size: 1.6rem;
   display: inline;
   text-align: center;
   /* -webkit-margin-start: 2rem; */
@@ -133,18 +163,22 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 .nav-link2:hover,
 .nav-link2:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: #0f172a !important;
+  background-color: rgba(226, 232, 240, 0.7) !important;
   outline: none;
 }
 
 #navBar nav {
-  background-color: #121212 !important;
-  /* background-color: black !important; */
-  font-size: 1.75rem;
+  background: var(
+    --footer-gradient,
+    linear-gradient(135deg, #f5f5f5 0%, #d9d9d9 50%, #bcbcbc 100%)
+  ) !important;
+  font-size: 1.6rem;
   display: flex;
   justify-content: center;
-  color: #f5f5f5 !important;
+  color: #1f2933 !important;
+  border-radius: 1rem;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
 }
 
 .navBar img {
@@ -152,39 +186,46 @@ button #hamburguesa.navBar-toggler.collapsed{
   padding: 1rem;
   display: flex;
   justify-content: center;
-  color: #f5f5f5 !important;
+  color: #1f2933 !important;
 }
 
 .navBar span {
-  background-color: #121212 !important;
-  /* background-color: black !important; */
+  background: transparent;
   font-size: 2.2rem;
-  color: #f5f5f5 !important;
-  font-family: "Times New Roman", Times, serif;
+  color: #1f2933 !important;
+  font-family: "Poppins", sans-serif;
+  font-weight: 600;
 }
 
 #booton {
-  font-family: "Quicksand";
-  font-size: 1.75rem;
-  color: #f5f5f5 !important;
-  background-color: #1b1b1b !important;
-  border: 1px solid #3a3a3a !important;
+  font-family: "Poppins", sans-serif;
+  font-size: 1.6rem;
+  color: #0f172a !important;
+  background: rgba(255, 255, 255, 0.6) !important;
+  border: 1px solid rgba(31, 41, 51, 0.25) !important;
+  border-radius: 999px;
+  padding: 0.6rem 1.8rem;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.12);
+  transition: transform 0.3s ease, box-shadow 0.3s ease,
+    background-color 0.3s ease;
 }
 #booton:hover,
 #booton:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
-  border-color: #4a4a4a !important;
+  color: #0b1120 !important;
+  background-color: rgba(255, 255, 255, 0.85) !important;
+  border-color: rgba(31, 41, 51, 0.35) !important;
   outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.2);
 }
 
 #user {
-  font-family: "Quicksand";
-  font-size: 1.75rem;
-  color: #e0e0e0 !important;
+  font-family: "Poppins", sans-serif;
+  font-size: 1.6rem;
+  color: #1f2933 !important;
 }
 #user:focus {
-  outline: 2px solid #4a4a4a;
+  outline: 2px solid rgba(31, 41, 51, 0.35);
   outline-offset: 2px;
 }
 
@@ -254,7 +295,7 @@ button #hamburguesa.navBar-toggler.collapsed{
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #e0e0e0;
+    color: #0f172a;
   }
 }
 /* 

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -1,9 +1,10 @@
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap");
+
 html {
-    font-size: 62.5%;
-  }
-  
-  body #root {
-    font-family: "Quicksand";
-    background-color: #f1faee;
-  }
-  
+  font-size: 62.5%;
+}
+
+body #root {
+  font-family: "Quicksand";
+  background-color: #f1faee;
+}


### PR DESCRIPTION
## Summary
- centralize the shared gray gradient with a CSS custom property and apply it to the footer and navigation layouts
- restyle the navbar to use the new gradient, Poppins typography, and cohesive hover/border treatments for toggles, links, and actions
- import the Poppins family globally so navigation elements render with the updated font stack

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfc278c6a08323a113d094c2cdb373