### PR TITLE
feat: modernize navbar glass styling

### DIFF
--- a/front/public/index.html
+++ b/front/public/index.html
@@ -17,6 +17,10 @@
 
   <link rel="preconnect" href="https://fonts.gstatic.com" />
   <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@600&display=swap" rel="stylesheet" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700&display=swap"
+    rel="stylesheet"
+  />
   <!-- <script src="https://cdn.fromdoppler.com/formgenerator/latest/vendor.js?47288510"></script>
     <link rel="stylesheet" href="https://cdn.fromdoppler.com/formgenerator/latest/styles.css?47288510" /> -->
   <title>Distripollo App</title>

--- a/front/src/components/NavBar.jsx
+++ b/front/src/components/NavBar.jsx
@@ -71,14 +71,18 @@ const NavBar = () => {
 
   return (
     <div>
-      <div id="navBar" className="navBar mr-auto">
+      <div id="navBar" className="navBar navBar--glass mr-auto">
         <Navbar bg="light" expand="lg">
           <img src={logo} alt="logo" />
           <Link className="nav" to="/">
             <Navbar.Brand>Distri Pollo</Navbar.Brand>
           </Link>
-     
-          <Navbar.Toggle id="hamburguesa" aria-controls="basic-navbar-nav" />
+
+          <Navbar.Toggle
+            id="hamburguesa"
+            className="navBar-toggle--glass"
+            aria-controls="basic-navbar-nav"
+          />
           <Navbar.Collapse id="basic-navbar-nav-light">
             {/* <Navbar className="mr-auto"> */}
             <Nav>
@@ -406,7 +410,7 @@ const NavBar = () => {
             )}
             <button
               id="booton"
-              className="btn btn-outline-info"
+              className="btn btn-outline-info navBar__userButton--glass"
               onClick={handleLogin}
             >
               {user}

--- a/front/src/css/navbar.css
+++ b/front/src/css/navbar.css
@@ -1,3 +1,20 @@
+/*
+  Diseño de la barra de navegación
+  - Variante clásica: utilizar la clase `.navBar` sola para mantener el fondo sólido oscuro.
+  - Variante glassmorphism: combinar `.navBar` con `.navBar--glass` para activar el degradado translúcido.
+  Cambiar la clase aplicada en `NavBar.jsx` permite alternar fácilmente qué estilo se usa en producción.
+*/
+
+:root {
+  --footer-gradient-start-rgb: 29, 53, 87;
+  --footer-gradient-end-rgb: 69, 123, 157;
+  --footer-gradient: linear-gradient(
+    120deg,
+    rgb(var(--footer-gradient-start-rgb)),
+    rgb(var(--footer-gradient-end-rgb))
+  );
+}
+
 .navBar-toggler {
   color: #f5f5f5 !important;
   background-color: #121212 !important;
@@ -21,6 +38,17 @@
   padding: 1rem;
 }
 
+.navBar--glass {
+  background: linear-gradient(
+      120deg,
+      rgba(var(--footer-gradient-start-rgb), 0.82),
+      rgba(var(--footer-gradient-end-rgb), 0.72)
+    );
+  backdrop-filter: blur(12px);
+  box-shadow: 0 12px 32px rgba(29, 53, 87, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
 .navBar-toggler:hover,
 .navBar-toggler:focus {
   color: #e0e0e0 !important;
@@ -28,28 +56,35 @@
   border-color: #4a4a4a !important;
   outline: none;
 }
-button #hamburguesa.navBar-toggler.collapsed{
+button #hamburguesa.navBar-toggler.collapsed {
   background: #1b1b1b !important;
 }
 .nav-link {
-  font-family: "Quicksand";
+  font-family: "Montserrat", sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12rem;
   /* background-color: #1d3557 !important; */
   /* background-color: black !important; */
-  font-size: 1.75rem;
+  font-size: 1.6rem;
   display: inline;
   text-align: center;
   /* -webkit-margin-start: 2rem; */
   color: #f5f5f5 !important;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 .nav-link:hover,
 .nav-link:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: #ffffff !important;
+  background-color: rgba(255, 255, 255, 0.12) !important;
   outline: none;
 }
 
 #navbarScrollingDropdown {
-  font-family: "Quicksand";
+  font-family: "Montserrat", sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.12rem;
+  text-transform: uppercase;
   /* background-color: black !important; */
   /* background-color: #1d3557 !important; */
   font-size: 1.75rem;
@@ -64,25 +99,32 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 
 .dropdown-menu {
-  font-family: "Quicksand";
-  font-size: 1.5rem;
+  font-family: "Montserrat", sans-serif;
+  font-weight: 600;
+  font-size: 1.4rem;
+  letter-spacing: 0.1rem;
+  text-transform: uppercase;
   /* background-color: black !important; */
-  background-color: #1b1b1b !important;
+  background-color: rgba(18, 18, 18, 0.82) !important;
   color: #f5f5f5 !important;
-  border: 1px solid #3a3a3a !important;
+  border: 1px solid rgba(255, 255, 255, 0.15) !important;
+  backdrop-filter: blur(12px);
 }
 
 .dropdown-item {
-  font-family: "Quicksand";
-  font-size: 1.5rem;
+  font-family: "Montserrat", sans-serif;
+  font-weight: 600;
+  font-size: 1.4rem;
+  letter-spacing: 0.1rem;
   /* background-color: black !important; */
-  background-color: #1b1b1b !important;
+  background-color: transparent !important;
   color: #f5f5f5 !important;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 .dropdown-item:hover,
 .dropdown-item:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: #1d3557 !important;
+  background-color: rgba(255, 255, 255, 0.24) !important;
 }
 
 .nav-link1 {
@@ -164,23 +206,39 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 
 #booton {
-  font-family: "Quicksand";
-  font-size: 1.75rem;
+  font-family: "Montserrat", sans-serif;
+  font-size: 1.6rem;
+  letter-spacing: 0.12rem;
+  text-transform: uppercase;
   color: #f5f5f5 !important;
-  background-color: #1b1b1b !important;
-  border: 1px solid #3a3a3a !important;
+  background-color: rgba(18, 18, 18, 0.5) !important;
+  border: 1px solid rgba(255, 255, 255, 0.35) !important;
+  box-shadow: 0 0 18px rgba(69, 123, 157, 0.35);
+  backdrop-filter: blur(10px);
+  transition: background-color 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+#booton.navBar__userButton--glass {
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 #booton:hover,
 #booton:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
-  border-color: #4a4a4a !important;
+  color: #ffffff !important;
+  background-color: rgba(255, 255, 255, 0.22) !important;
+  border-color: rgba(255, 255, 255, 0.6) !important;
+  box-shadow: 0 0 24px rgba(69, 123, 157, 0.55);
   outline: none;
 }
 
 #user {
-  font-family: "Quicksand";
-  font-size: 1.75rem;
+  font-family: "Montserrat", sans-serif;
+  font-size: 1.6rem;
+  letter-spacing: 0.12rem;
+  text-transform: uppercase;
   color: #e0e0e0 !important;
 }
 #user:focus {
@@ -192,14 +250,20 @@ button #hamburguesa.navBar-toggler.collapsed{
   height: 45px;
 }
 
-@media (max-width: 768px) {
-  .navBar img {
-    display: flex;
-    justify-content: flex-start;
-    align-self: flex-end;
-    justify-content: right;
-    padding: 1rem;
-  }
+.navBar-toggle--glass {
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.35) !important;
+  background-color: rgba(18, 18, 18, 0.55) !important;
+  color: #f5f5f5 !important;
+  backdrop-filter: blur(8px);
+  transition: background-color 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.navBar-toggle--glass:hover,
+.navBar-toggle--glass:focus {
+  background-color: rgba(255, 255, 255, 0.2) !important;
+  border-color: rgba(255, 255, 255, 0.6) !important;
+  box-shadow: 0 0 18px rgba(69, 123, 157, 0.45);
 }
 
 @media (max-width: 768px) {
@@ -208,7 +272,18 @@ button #hamburguesa.navBar-toggler.collapsed{
     justify-content: flex-start;
     align-self: flex-end;
     justify-content: right;
-    padding: 1rem;
+    padding: 0.6rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .navBar--glass {
+    background: linear-gradient(
+        120deg,
+        rgba(var(--footer-gradient-start-rgb), 0.92),
+        rgba(var(--footer-gradient-end-rgb), 0.85)
+      );
+    padding: 0.75rem;
   }
 }
 
@@ -222,7 +297,7 @@ button #hamburguesa.navBar-toggler.collapsed{
 @media (max-width: 768px) {
   .navBar nav {
     font-size: 1rem;
-    padding: 0.5rem;
+    padding: 0.35rem;
   }
 }
 
@@ -254,7 +329,8 @@ button #hamburguesa.navBar-toggler.collapsed{
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #e0e0e0;
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.24) !important;
   }
 }
 /* 


### PR DESCRIPTION
## Summary
- add a glassmorphism variant for the navbar with shared gradient variables and documentation for selecting styles
- refresh navigation links, dropdowns, and buttons with Montserrat typography and translucent hover treatments
- import the Montserrat font and tweak responsive behaviour to keep the glass effect legible on mobile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfc4fd041c8323ae785939b5aef5e2