### PR TITLE
Update navbar and footer with shared grey gradient

### DIFF
--- a/front/src/css/footer.css
+++ b/front/src/css/footer.css
@@ -1,6 +1,9 @@
 #footer {
-  background-color: #1d3557 !important;
+  background: var(--footer-gradient);
+  background-color: rgb(var(--footer-gradient-end-rgb)) !important;
   min-height: 5rem;
+  width: 100%;
+  margin: 0 auto;
   padding: 1rem;
   text-align: center;
   color: #f1faee !important;

--- a/front/src/css/navbar.css
+++ b/front/src/css/navbar.css
@@ -1,35 +1,75 @@
-.navBar-toggler {
-  color: #f5f5f5 !important;
-  background-color: #121212 !important;
-  border: 1px solid #3a3a3a !important;
-}
-.navBar h4 {
-  font-size: 1.75rem;
-  text-align: center;
-
-  background-color: #121212 !important;
-  color: #f5f5f5 !important;
-  font-family: "Quicksand";
+/*
+  Navbar variants:
+  - Use `.navBar.navBar--glass` for the translucent grey gradient (default for production layouts).
+  - Use `.navBar.navBar--solidGrey` when you need a fully opaque header that matches the footer gradient.
+*/
+:root {
+  --footer-gradient-start-rgb: 45, 45, 45;
+  --footer-gradient-end-rgb: 95, 95, 95;
+  --footer-gradient: linear-gradient(
+    135deg,
+    rgb(var(--footer-gradient-start-rgb)),
+    rgb(var(--footer-gradient-end-rgb))
+  );
+  --navbar-box-shadow: 0 12px 30px rgba(45, 45, 45, 0.45);
 }
 
 .navBar {
-  /* background-color: black !important; */
-  background-color: #121212 !important;
+  width: 100%;
+  margin: 0 auto;
+  background: var(--footer-gradient);
+  background-color: rgb(var(--footer-gradient-start-rgb));
   color: #f5f5f5 !important;
   font-size: 2rem;
   font-family: "Times New Roman", Times, serif;
   padding: 1rem;
+  box-shadow: var(--navbar-box-shadow);
+}
+
+.navBar--glass {
+  width: 100%;
+  margin: 0 auto;
+  background: linear-gradient(
+    135deg,
+    rgba(var(--footer-gradient-start-rgb), 0.7),
+    rgba(var(--footer-gradient-end-rgb), 0.7)
+  );
+  background-color: rgba(var(--footer-gradient-start-rgb), 0.7);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  box-shadow: var(--navbar-box-shadow);
+}
+
+.navBar--solidGrey {
+  width: 100%;
+  margin: 0 auto;
+  background: var(--footer-gradient);
+  background-color: rgb(var(--footer-gradient-start-rgb));
+  box-shadow: var(--navbar-box-shadow);
+}
+
+.navBar-toggler {
+  color: #f5f5f5 !important;
+  background-color: rgb(var(--footer-gradient-start-rgb)) !important;
+  border: 1px solid rgba(var(--footer-gradient-end-rgb), 0.6) !important;
+}
+.navBar h4 {
+  font-size: 1.75rem;
+  text-align: center;
+  background-color: transparent;
+  color: #f5f5f5 !important;
+  font-family: "Quicksand";
 }
 
 .navBar-toggler:hover,
 .navBar-toggler:focus {
   color: #e0e0e0 !important;
-  background-color: #1b1b1b !important;
-  border-color: #4a4a4a !important;
+  background-color: rgba(var(--footer-gradient-start-rgb), 0.85) !important;
+  border-color: rgba(var(--footer-gradient-end-rgb), 0.75) !important;
   outline: none;
 }
-button #hamburguesa.navBar-toggler.collapsed{
-  background: #1b1b1b !important;
+button #hamburguesa.navBar-toggler.collapsed {
+  background: rgba(var(--footer-gradient-start-rgb), 0.85) !important;
 }
 .nav-link {
   font-family: "Quicksand";
@@ -44,7 +84,7 @@ button #hamburguesa.navBar-toggler.collapsed{
 .nav-link:hover,
 .nav-link:focus {
   color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  background-color: rgba(var(--footer-gradient-start-rgb), 0.65) !important;
   outline: none;
 }
 
@@ -67,22 +107,22 @@ button #hamburguesa.navBar-toggler.collapsed{
   font-family: "Quicksand";
   font-size: 1.5rem;
   /* background-color: black !important; */
-  background-color: #1b1b1b !important;
+  background-color: rgba(var(--footer-gradient-start-rgb), 0.92) !important;
   color: #f5f5f5 !important;
-  border: 1px solid #3a3a3a !important;
+  border: 1px solid rgba(var(--footer-gradient-end-rgb), 0.55) !important;
 }
 
 .dropdown-item {
   font-family: "Quicksand";
   font-size: 1.5rem;
   /* background-color: black !important; */
-  background-color: #1b1b1b !important;
+  background-color: rgba(var(--footer-gradient-start-rgb), 0.92) !important;
   color: #f5f5f5 !important;
 }
 .dropdown-item:hover,
 .dropdown-item:focus {
   color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  background-color: rgba(var(--footer-gradient-end-rgb), 0.35) !important;
 }
 
 .nav-link1 {
@@ -98,7 +138,7 @@ button #hamburguesa.navBar-toggler.collapsed{
 .nav-link1:hover,
 .nav-link1:focus {
   color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  background-color: rgba(var(--footer-gradient-start-rgb), 0.65) !important;
   outline: none;
 }
 
@@ -115,7 +155,7 @@ button #hamburguesa.navBar-toggler.collapsed{
 .nav-link3:hover,
 .nav-link3:focus {
   color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  background-color: rgba(var(--footer-gradient-start-rgb), 0.65) !important;
   outline: none;
 }
 
@@ -134,12 +174,12 @@ button #hamburguesa.navBar-toggler.collapsed{
 .nav-link2:hover,
 .nav-link2:focus {
   color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  background-color: rgba(var(--footer-gradient-start-rgb), 0.65) !important;
   outline: none;
 }
 
 #navBar nav {
-  background-color: #121212 !important;
+  background-color: transparent;
   /* background-color: black !important; */
   font-size: 1.75rem;
   display: flex;
@@ -156,7 +196,7 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 
 .navBar span {
-  background-color: #121212 !important;
+  background-color: transparent;
   /* background-color: black !important; */
   font-size: 2.2rem;
   color: #f5f5f5 !important;
@@ -167,14 +207,14 @@ button #hamburguesa.navBar-toggler.collapsed{
   font-family: "Quicksand";
   font-size: 1.75rem;
   color: #f5f5f5 !important;
-  background-color: #1b1b1b !important;
-  border: 1px solid #3a3a3a !important;
+  background-color: rgba(var(--footer-gradient-start-rgb), 0.85) !important;
+  border: 1px solid rgba(var(--footer-gradient-end-rgb), 0.55) !important;
 }
 #booton:hover,
 #booton:focus {
   color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
-  border-color: #4a4a4a !important;
+  background-color: rgba(var(--footer-gradient-end-rgb), 0.4) !important;
+  border-color: rgba(var(--footer-gradient-end-rgb), 0.65) !important;
   outline: none;
 }
 
@@ -184,7 +224,7 @@ button #hamburguesa.navBar-toggler.collapsed{
   color: #e0e0e0 !important;
 }
 #user:focus {
-  outline: 2px solid #4a4a4a;
+  outline: 2px solid rgba(var(--footer-gradient-end-rgb), 0.65);
   outline-offset: 2px;
 }
 


### PR DESCRIPTION
## Summary
- define shared grey gradient variables for the navbar/footer and document the glass vs. solid variants
- refresh navbar colors, shadows, and dropdown styling to use the new grey palette
- align the footer background, sizing, and padding with the shared gradient theme

## Testing
- npm install *(fails: dependency conflict with react-datalist-input)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc85350cc83238696a060736f96fa