### PR TITLE
Apply gray gradient theme to navbar and footer

### DIFF
--- a/front/src/components/Footer.jsx
+++ b/front/src/components/Footer.jsx
@@ -5,56 +5,35 @@ import logo from "../images/logocode.png";
 
 const Footer = () => {
   return (
-    <footer id="footer">
+    <footer id="footer" className="degradado-gris text-light py-3">
       <div className="container">
-        <div className="row">
-          <div className="col-lg-4 col-xs-12 col-md-12">
-            <div className="row">
-              <div className="col-lg-12 col-md-12 visible-md visible-lg copyright">
-                <img src={logo} alt="logo" />
-                <p>
-                  © Copyright 2021 <strong> Distripollo </strong>
-                </p>
-              </div>
-              <div className="col-lg-12 col-md-12 visible-md visible-lg copyright">
-                <p>
-                  <strong> by Abeto Tech - División Web </strong>
-                </p>
-              </div>
-            </div>
+        <div className="row align-items-center">
+          <div className="col-lg-4 col-md-12 mb-3 mb-lg-0 text-center text-lg-left">
+            <img src={logo} alt="logo" className="footer-logo mb-2" />
+            <p className="mb-1">
+              © Copyright 2021 <strong> Distripollo </strong>
+            </p>
+            <p className="mb-0">
+              <strong> by Abeto Tech - División Web </strong>
+            </p>
           </div>
-          <div className="col-4">
-            {/* <a title="Whatsapp" 
-                        href="https://wa.link/0zbip1"
-                        target="_blank">
-                        <img className="imag1" 
-                            src="https://play-lh.googleusercontent.com/bYtqbOcTYOlgc6gqZ2rwb8lptHuwlNE75zYJu6Bn076-hTmvd96HH-6v7S0YUAAJXoJN" 
-                            alt="Whatsapp" 
-                            width="100" 
-                            height="100"
-                        />
-                    </a> */}
-            {/* <h3>CONTACTANOS</h3> */}
-          </div>
-
-          <div id="contacto" className="col-lg-4 col-xs-12 col-md-12">
-            <div className="row">
-              <div className="col-md-12 hidden-xs hidden-sm ">
-                <p className="contact">
-                  <strong>CONTACTO</strong>
-                </p>
-                <p className="description-contact">
-                  Por consultas comuníquese con nosotros:
-                </p>
-                <p className="description-contact">
-                  Lun a Sab de 9 a 18 Hs - Tel +3816298096
-                </p>
-                {/* <p className="description-contact">Cel +5493816900030 +5493814909195</p> */}
-                <p className="description-contact">
-                  Domicilio: Eudoro Araoz 933
-                </p>
-              </div>
-            </div>
+          <div className="col-lg-4 d-none d-lg-block" />
+          <div
+            id="contacto"
+            className="col-lg-4 col-md-12 text-center text-lg-right"
+          >
+            <p className="contact mb-1">
+              <strong>CONTACTO</strong>
+            </p>
+            <p className="description-contact mb-1">
+              Por consultas comuníquese con nosotros:
+            </p>
+            <p className="description-contact mb-1">
+              Lun a Sab de 9 a 18 Hs - Tel +3816298096
+            </p>
+            <p className="description-contact mb-0">
+              Domicilio: Eudoro Araoz 933
+            </p>
           </div>
         </div>
       </div>

--- a/front/src/components/NavBar.jsx
+++ b/front/src/components/NavBar.jsx
@@ -72,7 +72,7 @@ const NavBar = () => {
   return (
     <div>
       <div id="navBar" className="navBar mr-auto">
-        <Navbar bg="light" expand="lg">
+        <Navbar className="navbar-dark degradado-gris" expand="lg">
           <img src={logo} alt="logo" />
           <Link className="nav" to="/">
             <Navbar.Brand>Distri Pollo</Navbar.Brand>

--- a/front/src/css/footer.css
+++ b/front/src/css/footer.css
@@ -1,45 +1,25 @@
+.degradado-gris {
+  background: linear-gradient(135deg, #3a3a3a 0%, #4b4b4b 50%, #5c5c5c 100%) !important;
+  color: #f5f5f5 !important;
+  font-family: "Poppins", sans-serif;
+}
+
 #footer {
-  background-color: #1d3557 !important;
-  min-height: 5rem;
-  padding: 1rem;
-  text-align: center;
-  color: #f1faee !important;
-  font-size: 1rem !important;
+  font-size: 1rem;
 }
 
 #footer p {
-  font-size: 1.2rem;
+  font-size: 1.1rem;
 }
 
-#footer a {
-  color: #f1faee !important;
+.degradado-gris a {
+  color: #f5f5f5 !important;
 }
 
-#footer img {
+.degradado-gris a:hover {
+  color: #e0e0e0 !important;
+}
+
+.footer-logo {
   height: 6rem;
-  padding: 1rem;
-}
-
-#footer .imag1 {
-  margin-top: 15px;
-  height: 6rem;
-  width: 6rem;
-}
-/*footer centrado*/
-@media (max-width: 1024px) {
-  #contacto {
-    text-align: center !important;
-  }
-}
-
-@media (min-width: 1024px) {
-  #contacto {
-    text-align: right !important;
-  }
-}
-
-@media (max-width: 1024px) {
-  #footer .imag1 {
-    margin-left: 120px !important;
-  }
 }

--- a/front/src/css/navbar.css
+++ b/front/src/css/navbar.css
@@ -1,3 +1,9 @@
+.degradado-gris {
+  background: linear-gradient(135deg, #3a3a3a 0%, #4b4b4b 50%, #5c5c5c 100%) !important;
+  color: #f5f5f5 !important;
+  font-family: "Poppins", sans-serif;
+}
+
 .navBar-toggler {
   color: #f5f5f5 !important;
   background-color: #121212 !important;
@@ -6,18 +12,17 @@
 .navBar h4 {
   font-size: 1.75rem;
   text-align: center;
-
-  background-color: #121212 !important;
+  background: transparent;
   color: #f5f5f5 !important;
-  font-family: "Quicksand";
+  font-family: "Poppins", sans-serif;
 }
 
 .navBar {
   /* background-color: black !important; */
-  background-color: #121212 !important;
+  background: linear-gradient(135deg, #3a3a3a 0%, #4b4b4b 50%, #5c5c5c 100%) !important;
   color: #f5f5f5 !important;
   font-size: 2rem;
-  font-family: "Times New Roman", Times, serif;
+  font-family: "Poppins", sans-serif;
   padding: 1rem;
 }
 
@@ -139,8 +144,7 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 
 #navBar nav {
-  background-color: #121212 !important;
-  /* background-color: black !important; */
+  background: transparent !important;
   font-size: 1.75rem;
   display: flex;
   justify-content: center;
@@ -156,11 +160,10 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 
 .navBar span {
-  background-color: #121212 !important;
-  /* background-color: black !important; */
+  background: transparent;
   font-size: 2.2rem;
   color: #f5f5f5 !important;
-  font-family: "Times New Roman", Times, serif;
+  font-family: "Poppins", sans-serif;
 }
 
 #booton {


### PR DESCRIPTION
## Summary
- replace the navbar's background prop with a reusable gray gradient class and aligned typography
- update navbar and footer styles to share the degradado-gris gradient palette and Poppins font
- simplify the footer markup to lean on Bootstrap utilities while keeping the existing content

## Testing
- NODE_OPTIONS=--openssl-legacy-provider npm start


------
https://chatgpt.com/codex/tasks/task_e_68dfd09e07d88323b02723551f25f3ff