### PR TITLE
Update navbar toggle styling

### DIFF
--- a/front/src/components/NavBar.jsx
+++ b/front/src/components/NavBar.jsx
@@ -78,7 +78,11 @@ const NavBar = () => {
             <Navbar.Brand>Distri Pollo</Navbar.Brand>
           </Link>
      
-          <Navbar.Toggle id="hamburguesa" aria-controls="basic-navbar-nav" />
+          <Navbar.Toggle
+            id="hamburguesa"
+            className="navBar-toggler"
+            aria-controls="basic-navbar-nav"
+          />
           <Navbar.Collapse id="basic-navbar-nav-light">
             {/* <Navbar className="mr-auto"> */}
             <Nav>

--- a/front/src/css/navbar.css
+++ b/front/src/css/navbar.css
@@ -1,7 +1,9 @@
 .navBar-toggler {
   color: #f5f5f5 !important;
-  background-color: #121212 !important;
-  border: 1px solid #3a3a3a !important;
+  background-image: linear-gradient(135deg, #5f5f5f, #2f2f2f) !important;
+  border: 1px solid #7a7a7a !important;
+  transition: background-image 0.2s ease-in-out, color 0.2s ease-in-out,
+    border-color 0.2s ease-in-out;
 }
 .navBar h4 {
   font-size: 1.75rem;
@@ -23,13 +25,18 @@
 
 .navBar-toggler:hover,
 .navBar-toggler:focus {
-  color: #e0e0e0 !important;
-  background-color: #1b1b1b !important;
-  border-color: #4a4a4a !important;
+  color: #ffffff !important;
+  background-image: linear-gradient(135deg, #6f6f6f, #3b3b3b) !important;
+  border-color: #909090 !important;
   outline: none;
 }
-button #hamburguesa.navBar-toggler.collapsed{
-  background: #1b1b1b !important;
+#hamburguesa.navBar-toggler.collapsed {
+  background-image: linear-gradient(135deg, #5f5f5f, #2f2f2f) !important;
+}
+#hamburguesa.navBar-toggler:not(.collapsed) {
+  color: #ffffff !important;
+  background-image: linear-gradient(135deg, #787878, #4a4a4a) !important;
+  border-color: #b5b5b5 !important;
 }
 .nav-link {
   font-family: "Quicksand";


### PR DESCRIPTION
## Summary
- add the custom `navBar-toggler` class to the navbar toggle component to supplement the Bootstrap defaults
- refresh the toggle styling with a gray gradient palette and improved active-state contrast while fixing the redundant selector

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfd5db20a483239d26e098a8011f7e