### PR TITLE
feat: restyle login page with dark theme

### DIFF
--- a/front/src/components/LoginForm.jsx
+++ b/front/src/components/LoginForm.jsx
@@ -59,51 +59,42 @@ const LoginForm = () => {
   return (
     <>
       <main>
-        <div className="row">
-          <div className="row-15">
-            <div className="col-12">
-              <form onSubmit={handleSubmit}>
-                <div className="form-group">
-                  <label className="">Correo electrónico</label>
-                  <input
-                    type="email"
-                    className="form-control"
-                    name="email"
-                    value={formValues.email}
-                    onChange={handleChange}
-                  />
-                </div>
-                <div className="form-group mt-2">
-                  <label className="">Contraseña</label>
-                  <input
-                    type="password"
-                    className="form-control"
-                    name="password"
-                    value={formValues.password}
-                    onChange={handleChange}
-                  />
-                </div>
-
-                <button
-                  type="submit"
-                  className="btn btn-info btn-block mt-2"
-                  disabled={user.loading}
-                >
-                  Enviar
-                </button>
-              </form>
-              {console.log(user.data.ok)}
-              {user.data.ok === false && (
-                <div className="alert alert-dark mt-3 text-center" role="alert">
-                  {user.data.err.message}
-                </div>
-              )}
-
-              {user.data.ok === true}
-   
-            </div>
+        <form className="login-form" onSubmit={handleSubmit}>
+          <div className="login-field">
+            <label htmlFor="login-email">Correo electrónico</label>
+            <input
+              id="login-email"
+              type="email"
+              className="form-control"
+              name="email"
+              value={formValues.email}
+              onChange={handleChange}
+            />
           </div>
-        </div>
+          <div className="login-field">
+            <label htmlFor="login-password">Contraseña</label>
+            <input
+              id="login-password"
+              type="password"
+              className="form-control"
+              name="password"
+              value={formValues.password}
+              onChange={handleChange}
+            />
+          </div>
+
+          <button type="submit" className="login-btn" disabled={user.loading}>
+            Enviar
+          </button>
+        </form>
+        {console.log(user.data.ok)}
+        {user.data.ok === false && (
+          <div className="alert alert-dark mt-3 text-center" role="alert">
+            {user.data.err.message}
+          </div>
+        )}
+
+        {user.data.ok === true}
       </main>
     </>
   );

--- a/front/src/css/login.css
+++ b/front/src/css/login.css
@@ -1,18 +1,108 @@
-.container {
-  font-size: 2rem;
-  font-family: "Quicksand";
+.login-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: #121212;
+  color: #f5f5f5;
+  padding: 4rem 1.5rem 2rem;
+  font-family: "Quicksand", sans-serif;
 }
 
-.container p {
-  font-size: 1.5rem;
-  font-family: "Quicksand";
+.login-card {
+  width: 100%;
+  max-width: 480px;
+  background-color: #1b1b1b;
+  border: 1px solid #2a2a2a;
+  border-radius: 1.5rem;
+  padding: 3.5rem 3rem;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+  margin: 0 auto;
 }
 
-.container span {
-  font-size: 1.5rem;
-  font-family: "Quicksand";
+.login-card h1 {
+  font-size: 3rem;
+  font-weight: 600;
+  color: #f5f5f5;
+  margin-bottom: 0;
 }
 
-.btn.btn-info{
-  font-size: 1.5rem;
-} 
+.login-card p,
+.login-card span {
+  font-size: 1.6rem;
+  color: #d6d6d6;
+}
+
+.login-card .text-muted {
+  color: #b0b0b0 !important;
+}
+
+.login-card .text-center span {
+  display: inline-block;
+  line-height: 1.6;
+}
+
+.login-card .alert {
+  background-color: #252525;
+  border-color: #3a3a3a;
+  color: #f5f5f5;
+  font-size: 1.4rem;
+}
+
+@media (max-width: 992px) {
+  .login-card {
+    padding: 3rem 2.5rem;
+  }
+
+  .login-card h1 {
+    font-size: 2.6rem;
+  }
+
+  .login-card p,
+  .login-card span {
+    font-size: 1.5rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .login-page {
+    padding: 3rem 1.5rem 1.5rem;
+  }
+
+  .login-card {
+    padding: 2.5rem 2rem;
+    max-width: 420px;
+    margin: 0 auto;
+  }
+
+  .login-card h1 {
+    font-size: 2.4rem;
+  }
+
+  .login-card p,
+  .login-card span {
+    font-size: 1.4rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .login-page {
+    padding: 2.5rem 1.25rem 1.5rem;
+  }
+
+  .login-card {
+    padding: 2rem 1.75rem;
+    border-radius: 1rem;
+    margin: 0 auto;
+  }
+
+  .login-card h1 {
+    font-size: 2.1rem;
+  }
+
+  .login-card p,
+  .login-card span {
+    font-size: 1.3rem;
+  }
+}

--- a/front/src/css/loginform.css
+++ b/front/src/css/loginform.css
@@ -1,22 +1,100 @@
-.form-group label {
-  font-size: 1.5rem;
-  font-family: "Quicksand";
-}
-.form-group input {
-  font-size: 1.5rem;
-  font-family: "Quicksand";
-}
-.alert {
-  font-size: 1.5rem;
-  font-family: "Quicksand";
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin-top: 2rem;
 }
 
-.btn {
-  font-size: 1.5rem;
-  font-family: "Quicksand";
+.login-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-.form-group button {
-  font-size: 3rem;
-  font-family: "Quicksand";
+.login-field label {
+  font-size: 1.6rem;
+  color: #f5f5f5;
+  font-family: "Quicksand", sans-serif;
+}
+
+.login-field .form-control {
+  background-color: #121212;
+  border: 1px solid #3a3a3a;
+  border-radius: 1rem;
+  padding: 1.25rem 1.5rem;
+  font-size: 1.6rem;
+  color: #f5f5f5;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.login-field .form-control::placeholder {
+  color: #bdbdbd;
+}
+
+.login-field .form-control:focus {
+  border-color: #4a4a4a;
+  box-shadow: 0 0 0 3px rgba(74, 74, 74, 0.35);
+  outline: none;
+}
+
+.login-btn {
+  width: 100%;
+  padding: 1.4rem 1.5rem;
+  font-size: 1.7rem;
+  font-family: "Quicksand", sans-serif;
+  font-weight: 600;
+  color: #f5f5f5;
+  background-color: #1b1b1b;
+  border: 1px solid #3a3a3a;
+  border-radius: 1rem;
+  transition: background-color 0.2s ease, border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.login-btn:hover,
+.login-btn:focus {
+  background-color: #2a2a2a;
+  border-color: #4a4a4a;
+  color: #e0e0e0;
+  outline: none;
+}
+
+.login-btn:focus-visible {
+  outline: 3px solid rgba(245, 245, 245, 0.35);
+  outline-offset: 3px;
+}
+
+.login-btn:disabled {
+  background-color: #1f1f1f;
+  border-color: #2f2f2f;
+  color: #9e9e9e;
+  cursor: not-allowed;
+}
+
+@media (max-width: 768px) {
+  .login-form {
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+  }
+
+  .login-field label,
+  .login-field .form-control {
+    font-size: 1.45rem;
+  }
+
+  .login-btn {
+    font-size: 1.6rem;
+    padding: 1.2rem 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .login-field label,
+  .login-field .form-control {
+    font-size: 1.35rem;
+  }
+
+  .login-btn {
+    font-size: 1.5rem;
+  }
 }

--- a/front/src/pages/Login.jsx
+++ b/front/src/pages/Login.jsx
@@ -5,30 +5,26 @@ import "../css/login.css";
 
 const Login = () => {
   return (
-    <div className="">
-      <div className="container mt-5">
-        <div className="row text-center mb-3">
-          <div className="col-12">
+    <>
+      <div className="login-page">
+        <div className="login-card">
+          <div className="text-center mb-3">
             <h1>Iniciar Sesión</h1>
           </div>
-        </div>
-        <div className="row">
-          <div className="col-lg-4 offset-lg-4">
-            <p className="text-center">Ingresa tu correo electrónico</p>
+          <p className="text-center">Ingresa tu correo electrónico</p>
 
-            <LoginForm />
+          <LoginForm />
 
-            <div className="text-center text-muted mt-4 mb-5">
-              <span>
-                Al continuar con tu correo aceptas los términos y condiciones y
-                el aviso de privacidad.
-              </span>
-            </div>
+          <div className="text-center text-muted mt-4">
+            <span>
+              Al continuar con tu correo aceptas los términos y condiciones y el
+              aviso de privacidad.
+            </span>
           </div>
         </div>
       </div>
       <Footer />
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- wrap the login page in dedicated containers to support a centered dark layout
- restyle the login form fields and button with dark theme variants and accessible focus styles
- update login page and form CSS with palette-aligned colors, spacing, and responsive typography adjustments

## Testing
- NODE_OPTIONS=--openssl-legacy-provider HOST=0.0.0.0 PORT=3000 npm start

------
https://chatgpt.com/codex/tasks/task_e_68dfdbbb36cc832395bcd1d8ccdd9f5f