### PR TITLE
Hide layout chrome on login route

### DIFF
--- a/front/src/components/Layout.jsx
+++ b/front/src/components/Layout.jsx
@@ -1,15 +1,17 @@
 import React from "react";
+import { useLocation } from "react-router-dom";
 import NavBar from "./NavBar";
 // import Redes from "../components/Redes"
-
 const Layout = (props) => {
+  const location = useLocation();
+  const hideChrome = location.pathname === "/login";
+
   return (
     <>
-      <NavBar />
+      {!hideChrome && <NavBar />}
       {props.children}
-      {/* <Redes /> */}
+      {/* {!hideChrome && <Redes />} */}
     </>
   );
 };
-
 export default Layout;


### PR DESCRIPTION
## Summary
- import the router location hook to detect the current path
- hide the navigation chrome when rendering the login route

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe4fcdc288323a8188d9b9fbcbea5