### PR TITLE
Remove footer from login page and adjust layout

### DIFF
--- a/front/src/css/login.css
+++ b/front/src/css/login.css
@@ -1,3 +1,8 @@
+.login-page {
+  min-height: 100vh;
+  padding: 3rem 0;
+}
+
 .container {
   font-size: 2rem;
   font-family: "Quicksand";
@@ -13,6 +18,6 @@
   font-family: "Quicksand";
 }
 
-.btn.btn-info{
+.btn.btn-info {
   font-size: 1.5rem;
-} 
+}

--- a/front/src/pages/Login.jsx
+++ b/front/src/pages/Login.jsx
@@ -1,12 +1,11 @@
 import React from "react";
 import LoginForm from "../components/LoginForm";
-import Footer from "../components/Footer";
 import "../css/login.css";
 
 const Login = () => {
   return (
-    <div className="">
-      <div className="container mt-5">
+    <div className="login-page d-flex align-items-center justify-content-center">
+      <div className="container">
         <div className="row text-center mb-3">
           <div className="col-12">
             <h1>Iniciar Sesión</h1>
@@ -27,7 +26,6 @@ const Login = () => {
           </div>
         </div>
       </div>
-      <Footer />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove the footer import and rendering from the login page to simplify the layout
- apply a dedicated login page wrapper with full-height flex centering and padding to keep the form centered without scroll

## Testing
- NODE_OPTIONS=--openssl-legacy-provider npm start (manually verified login layout)


------
https://chatgpt.com/codex/tasks/task_e_68dfe58597888323a5eb1fe9f5c24a8b