### PR TITLE
feat: add theme context provider

### DIFF
--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -30,43 +30,54 @@ import InformeRemitos from "./pages/InformeRemitos";
 import InformeStock from "./pages/InformeStock";
 import InformeOrdenAPreparar from "./pages/InformeOrdenAPreparar";
 import InformeHojaRuta from "./pages/InformeHojaRuta";
+import { ThemeProvider } from "./Context/ThemeContext";
 
 const App = () => {
   return (
     <>
       <Router>
-        <Layout>
-          <Switch>
-            <Route exact path="/" component={Home} />
-            <Route exact path="/login" component={Login} />
-            <Route exact path="/Comandas" component={Comandas} />
-            <Route exact path="/Camiones" component={Camiones} />
-            <Route exact path="/Mapas" component={Mapas} />
-            <Route exact path="/Remitos" component={Remitos} />
-            <Route exact path="/Stocks" component={Stocks} />
-            <Route exact path="/StocksPrev" component={StocksPrev} />
-            <Route exact path="/Clientes" component={Clientes} />
-            <Route exact path="/ClientesPrev" component={ClientesPrev} />
-            <Route exact path="/Proveedores" component={Proveedores} />
-            <Route exact path="/Localidades" component={Localidades} />
-            <Route exact path="/Empresas" component={Empresas} />
-            <Route exact path="/Producservs" component={Producservs} />
-            <Route exact path="/Rutas" component={Rutas} />
-            <Route exact path="/Rubros" component={Rubros} />
-            <Route exact path="/Marcas" component={Marcas} />
-            <Route exact path="/Precios" component={Precios} />
-            <Route exact path="/quienes" component={Quienes} />
-            <Route exact path="/InformeComandas" component={InformeComandas} />
-            <Route exact path="/InformeImpresion" component={InformeImpresion} />
-            <Route exact path="/InformeGestion" component={InformeGestion} />            
-            <Route exact path="/InformePreventas" component={InformePreventas} />
-            <Route exact path="/InformeRemitos" component={InformeRemitos} />
-            <Route exact path="/InformeStock" component={InformeStock} />
-            <Route exact path="/InformeOrdenAPreparar" component={InformeOrdenAPreparar}/>
-            <Route exact path="/InformeHojaRuta" component={InformeHojaRuta}/>
-            <Route exact path="/admin" component={Admin} />
-          </Switch>
-        </Layout>
+        <ThemeProvider>
+          <Layout>
+            <Switch>
+              <Route exact path="/" component={Home} />
+              <Route exact path="/login" component={Login} />
+              <Route exact path="/Comandas" component={Comandas} />
+              <Route exact path="/Camiones" component={Camiones} />
+              <Route exact path="/Mapas" component={Mapas} />
+              <Route exact path="/Remitos" component={Remitos} />
+              <Route exact path="/Stocks" component={Stocks} />
+              <Route exact path="/StocksPrev" component={StocksPrev} />
+              <Route exact path="/Clientes" component={Clientes} />
+              <Route exact path="/ClientesPrev" component={ClientesPrev} />
+              <Route exact path="/Proveedores" component={Proveedores} />
+              <Route exact path="/Localidades" component={Localidades} />
+              <Route exact path="/Empresas" component={Empresas} />
+              <Route exact path="/Producservs" component={Producservs} />
+              <Route exact path="/Rutas" component={Rutas} />
+              <Route exact path="/Rubros" component={Rubros} />
+              <Route exact path="/Marcas" component={Marcas} />
+              <Route exact path="/Precios" component={Precios} />
+              <Route exact path="/quienes" component={Quienes} />
+              <Route exact path="/InformeComandas" component={InformeComandas} />
+              <Route exact path="/InformeImpresion" component={InformeImpresion} />
+              <Route exact path="/InformeGestion" component={InformeGestion} />
+              <Route exact path="/InformePreventas" component={InformePreventas} />
+              <Route exact path="/InformeRemitos" component={InformeRemitos} />
+              <Route exact path="/InformeStock" component={InformeStock} />
+              <Route
+                exact
+                path="/InformeOrdenAPreparar"
+                component={InformeOrdenAPreparar}
+              />
+              <Route
+                exact
+                path="/InformeHojaRuta"
+                component={InformeHojaRuta}
+              />
+              <Route exact path="/admin" component={Admin} />
+            </Switch>
+          </Layout>
+        </ThemeProvider>
       </Router>
     </>
   );

--- a/front/src/Context/ThemeContext.jsx
+++ b/front/src/Context/ThemeContext.jsx
@@ -1,0 +1,40 @@
+import React, { createContext, useEffect, useMemo, useState } from "react";
+
+const defaultTheme = "light";
+
+export const ThemeContext = createContext({
+  theme: defaultTheme,
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(() => {
+    if (typeof window !== "undefined") {
+      const storedTheme = window.localStorage.getItem("theme");
+      if (storedTheme === "light" || storedTheme === "dark") {
+        return storedTheme;
+      }
+    }
+    return defaultTheme;
+  });
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("theme", theme);
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prevTheme) => (prevTheme === "light" ? "dark" : "light"));
+  };
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme,
+    }),
+    [theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};

--- a/front/src/components/Layout.jsx
+++ b/front/src/components/Layout.jsx
@@ -1,14 +1,26 @@
-import React from "react";
+import React, { useContext, useEffect } from "react";
 import NavBar from "./NavBar";
 // import Redes from "../components/Redes"
+import { ThemeContext } from "../Context/ThemeContext";
 
 const Layout = (props) => {
+  const { theme } = useContext(ThemeContext);
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      document.body.dataset.theme = theme;
+      return () => {
+        document.body.dataset.theme = "";
+      };
+    }
+  }, [theme]);
+
   return (
-    <>
+    <div className={`app-shell ${theme}`}>
       <NavBar />
       {props.children}
       {/* <Redes /> */}
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- add a reusable theme context provider with persistence in localStorage
- wrap the app layout with the theme provider to expose theme data to children
- update the layout component to apply theme classes and sync the document body dataset

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfe866dd54832396d52a12064bda17