### PR TITLE
Add theme context and wrap app with provider

### DIFF
--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import Error404 from "./pages/Error404";
 import Home from "./pages/Home";
 import Layout from "./components/Layout";
+import { ThemeProvider } from "./Context/ThemeContext";
 import Login from "./pages/Login";
 import Admin from "./pages/Admin";
 import Comandas from "./pages/Comandas";
@@ -33,7 +34,7 @@ import InformeHojaRuta from "./pages/InformeHojaRuta";
 
 const App = () => {
   return (
-    <>
+    <ThemeProvider>
       <Router>
         <Layout>
           <Switch>
@@ -68,7 +69,7 @@ const App = () => {
           </Switch>
         </Layout>
       </Router>
-    </>
+    </ThemeProvider>
   );
 };
 

--- a/front/src/Context/ThemeContext.jsx
+++ b/front/src/Context/ThemeContext.jsx
@@ -1,0 +1,62 @@
+import React, { createContext, useCallback, useEffect, useMemo, useState } from "react";
+
+const DEFAULT_THEME = "light";
+const STORAGE_KEY = "app-theme";
+
+export const ThemeContext = createContext({
+  theme: DEFAULT_THEME,
+  toggleTheme: () => {},
+});
+
+const getStoredTheme = () => {
+  if (typeof window === "undefined") {
+    return DEFAULT_THEME;
+  }
+
+  const storedTheme = window.localStorage.getItem(STORAGE_KEY);
+  return storedTheme || DEFAULT_THEME;
+};
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(getStoredTheme);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return undefined;
+    }
+
+    const className = `theme-${theme}`;
+    const body = document.body;
+
+    body.classList.remove("theme-light", "theme-dark");
+    body.classList.add(className);
+
+    return () => {
+      body.classList.remove(className);
+    };
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prevTheme) => (prevTheme === "dark" ? "light" : "dark"));
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme,
+    }),
+    [theme, toggleTheme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export default ThemeContext;


### PR DESCRIPTION
## Summary
- add a ThemeContext module that persists theme choice and applies body classes
- wrap the application router with ThemeProvider so components can access theme data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfed73558c83239fcc520f628d5d99