### PR TITLE
Add theme tokens and align front-end styling

### DIFF
--- a/front/src/Maps/Map.js
+++ b/front/src/Maps/Map.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import { GoogleMap, DirectionsRenderer } from '@react-google-maps/api';
 import axios from 'axios';
+import { getCssVariable } from '../helpers/theme';
 // import routes from '../routes2.json';
 
 const defaultLocation = { lat: -26.860128, lng: -65.21991 };
@@ -76,6 +77,8 @@ class Map extends React.Component {
       for (let index = 0; index < routesAux.length; index++) {
         let geo = new google.maps.LatLng(routesAux[index].location.lat,routesAux[index].location.lng)
         // var geo = new google.maps.LatLng(-26.860128, -65.21991);
+        const labelColor = getCssVariable('--color-text-primary', '#1b263b');
+
         new google.maps.Marker({
           position: geo,
           map,
@@ -83,7 +86,7 @@ class Map extends React.Component {
           // title: routesAux[index].location.id,
           optimized: false,
           label: {
-            color: 'black',
+            color: labelColor,
             fontWeight: "bold",
             fontSize: "15px",
             text: routesAux[index].location.id,

--- a/front/src/css/addclienteform.css
+++ b/front/src/css/addclienteform.css
@@ -1,6 +1,6 @@
 .form-check {
     font-size: 1.5rem;
-    color:red
+    color: var(--color-status-danger);
 }
 
 .form-check-input{

--- a/front/src/css/addcomandaform.css
+++ b/front/src/css/addcomandaform.css
@@ -12,7 +12,7 @@
 
 .form-check {
   font-size: 1.5rem;
-  color: red;
+  color: var(--color-status-danger);
 }
 
 .form-check-input {
@@ -46,11 +46,11 @@
 }
 
 #subform {
-  background-color: rgb(179, 183, 189);
+  background-color: var(--color-surface-muted);
 }
 
 #titulo {
-  background-color: rgb(179, 183, 189);
+  background-color: var(--color-surface-muted);
   margin-top: 1rem;
   padding: 0.5rem;
 }

--- a/front/src/css/addcrutaform.css
+++ b/front/src/css/addcrutaform.css
@@ -1,6 +1,6 @@
 .form-check {
     font-size: 1.5rem;
-    color:red
+    color: var(--color-status-danger);
 }
 
 .form-check-input{

--- a/front/src/css/addempresaform.css
+++ b/front/src/css/addempresaform.css
@@ -1,6 +1,6 @@
 .form-check {
     font-size: 1.5rem;
-    color:red
+    color: var(--color-status-danger);
 }
 
 .form-check-input{

--- a/front/src/css/addformdynamics.css
+++ b/front/src/css/addformdynamics.css
@@ -1,5 +1,5 @@
 h5.normal {
-  color:blue;
+  color: var(--color-status-info);
 }
 
 
@@ -81,14 +81,14 @@ input#total1.form-control {
 @media (max-width: 760px) {
   h5.responsive {
     display: inline;
-    color: blue;
+    color: var(--color-status-info);
   }
 }
 
 @media (max-width: 760px) {
   h5.normal {
     display: none;
-    color: blue;
+    color: var(--color-status-info);
   }
 }
 

--- a/front/src/css/addlocalidadform.css
+++ b/front/src/css/addlocalidadform.css
@@ -1,6 +1,6 @@
 .form-check {
   font-size: 1.5rem;
-  color: red;
+  color: var(--color-status-danger);
 }
 
 .form-check-input {

--- a/front/src/css/addmarcaform.css
+++ b/front/src/css/addmarcaform.css
@@ -1,6 +1,6 @@
 .form-check {
     font-size: 1.5rem;
-    color:red
+    color: var(--color-status-danger);
 }
 
 .form-check-input{

--- a/front/src/css/addprecioform.css
+++ b/front/src/css/addprecioform.css
@@ -1,3 +1,3 @@
 .compraventa {
-  color: blue;
+  color: var(--color-status-info);
 }

--- a/front/src/css/addproducservform.css
+++ b/front/src/css/addproducservform.css
@@ -1,6 +1,6 @@
 .form-check {
     font-size: 1.5rem;
-    color:red
+    color: var(--color-status-danger);
 }
 
 .form-check-input{

--- a/front/src/css/addproveedorform.css
+++ b/front/src/css/addproveedorform.css
@@ -1,6 +1,6 @@
 .form-check {
     font-size: 1.5rem;
-    color:red
+    color: var(--color-status-danger);
 }
 
 .form-check-input{

--- a/front/src/css/addrubroform.css
+++ b/front/src/css/addrubroform.css
@@ -1,6 +1,6 @@
 .form-check {
     font-size: 1.5rem;
-    color:red
+    color: var(--color-status-danger);
 }
 
 .form-check-input{

--- a/front/src/css/addstockform.css
+++ b/front/src/css/addstockform.css
@@ -4,7 +4,7 @@
 
 .form-check {
   font-size: 1.5rem;
-  color: red;
+  color: var(--color-status-danger);
 }
 
 .form-check-input {

--- a/front/src/css/admin.css
+++ b/front/src/css/admin.css
@@ -1,10 +1,12 @@
 .col {
-    background-color: #F1FAEE;
+    background-color: var(--color-surface-subtle);
+    color: var(--color-text-primary);
     font-size: 2rem;
 }
 
 .titulo {
-    background-color: #F1FAEE;
- 
+    background-color: var(--color-surface-subtle);
+    color: var(--color-text-secondary);
+
 }
 

--- a/front/src/css/busqueda.css
+++ b/front/src/css/busqueda.css
@@ -1,9 +1,9 @@
 .busqueda {
-  background-color: #e63946 !important;
+  background-color: var(--color-accent) !important;
   /* min-height: 4rem; */
   padding: 2rem;
   /* text-align: center; */
-  color: rgb(241, 232, 232);
+  color: var(--color-text-on-contrast);
   font-size: 1.5rem;
   margin-bottom: 2rem;
   display: flex;
@@ -21,24 +21,26 @@
 }
 
 #inlineFormCustomSelectPref {
-  background-color: rgb(214, 213, 213);
+  background-color: var(--color-input-bg);
 
-  /* color: white; */
+  /* color: var(--color-text-on-contrast); */
   font-size: 1rem;
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
   justify-content: center;
+  border: 1px solid var(--color-input-border);
+  color: var(--color-input-text);
 }
 
-/* 
+/*
 #menu123 {
-   
-    background-color: rgba(0, 0, 0, 0.5) !important;
-    color: white;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
-    font-size: 1.5rem;
-  } */
+  background-color: var(--color-overlay-strong) !important;
+  color: var(--color-text-on-contrast);
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  font-size: 1.5rem;
+}
+*/

--- a/front/src/css/cargando.css
+++ b/front/src/css/cargando.css
@@ -4,7 +4,7 @@
     margin-left: 150px;
   }
   .fountainTextG {
-    color: rgb(0, 0, 0);
+    color: var(--color-text-primary);
     font-family: Arial;
     font-size: 48px;
     text-decoration: none;
@@ -124,51 +124,51 @@
   @keyframes bounce_fountainTextG {
     0% {
       transform: scale(1);
-      color: rgb(0, 0, 0);
+      color: var(--color-text-primary);
     }
     100% {
       transform: scale(0.5);
-      color: rgb(255, 255, 255);
+      color: var(--color-text-on-contrast);
     }
   }
   @-o-keyframes bounce_fountainTextG {
     0% {
       -o-transform: scale(1);
-      color: rgb(0, 0, 0);
+      color: var(--color-text-primary);
     }
     100% {
       -o-transform: scale(0.5);
-      color: rgb(255, 255, 255);
+      color: var(--color-text-on-contrast);
     }
   }
   @-ms-keyframes bounce_fountainTextG {
     0% {
       -ms-transform: scale(1);
-      color: rgb(0, 0, 0);
+      color: var(--color-text-primary);
     }
     100% {
       -ms-transform: scale(0.5);
-      color: rgb(255, 255, 255);
+      color: var(--color-text-on-contrast);
     }
   }
   @-webkit-keyframes bounce_fountainTextG {
     0% {
       -webkit-transform: scale(1);
-      color: rgb(0, 0, 0);
+      color: var(--color-text-primary);
     }
     100% {
       -webkit-transform: scale(0.5);
-      color: rgb(255, 255, 255);
+      color: var(--color-text-on-contrast);
     }
   }
   @-moz-keyframes bounce_fountainTextG {
     0% {
       -moz-transform: scale(1);
-      color: rgb(0, 0, 0);
+      color: var(--color-text-primary);
     }
     100% {
       -moz-transform: scale(0.5);
-      color: rgb(255, 255, 255);
+      color: var(--color-text-on-contrast);
     }
   }
   

--- a/front/src/css/footer.css
+++ b/front/src/css/footer.css
@@ -1,10 +1,11 @@
 #footer {
-  background-color: #1d3557 !important;
+  background-color: var(--color-surface-contrast) !important;
   min-height: 5rem;
   padding: 1rem;
   text-align: center;
-  color: #f1faee !important;
+  color: var(--color-text-on-contrast) !important;
   font-size: 1rem !important;
+  box-shadow: var(--shadow-contrast);
 }
 
 #footer p {
@@ -12,7 +13,7 @@
 }
 
 #footer a {
-  color: #f1faee !important;
+  color: var(--color-text-on-contrast) !important;
 }
 
 #footer img {

--- a/front/src/css/home.css
+++ b/front/src/css/home.css
@@ -11,7 +11,7 @@
   }
   
   .text-grey {
-    color: #1d3557;
+    color: var(--color-text-secondary);
     margin-top: 20px;
   }
   /* 

--- a/front/src/css/invoice.css
+++ b/front/src/css/invoice.css
@@ -1,8 +1,18 @@
 .invoice button {
   width: 3.5rem;
   height: 3rem;
-  color: white;
-  background-color: blue;
+  color: var(--color-action-primary-text);
+  background-color: var(--color-action-primary-bg);
+  border: 1px solid var(--color-action-primary-bg);
+  border-radius: 0.4rem;
+  transition: background-color 0.2s ease;
+}
+
+.invoice button:hover,
+.invoice button:focus {
+  background-color: var(--color-action-primary-hover);
+  border-color: var(--color-action-primary-hover);
+  color: var(--color-action-primary-text);
 }
 
 .btn.btn-danger {

--- a/front/src/css/login.css
+++ b/front/src/css/login.css
@@ -1,18 +1,31 @@
 .container {
   font-size: 2rem;
   font-family: "Quicksand";
+  color: var(--color-text-primary);
 }
 
 .container p {
   font-size: 1.5rem;
   font-family: "Quicksand";
+  color: var(--color-text-secondary);
 }
 
 .container span {
   font-size: 1.5rem;
   font-family: "Quicksand";
+  color: var(--color-accent);
 }
 
 .btn.btn-info{
   font-size: 1.5rem;
-} 
+  background-color: var(--color-action-primary-bg);
+  color: var(--color-action-primary-text);
+  border-color: var(--color-action-primary-bg);
+  transition: background-color 0.2s ease;
+}
+
+.btn.btn-info:hover,
+.btn.btn-info:focus {
+  background-color: var(--color-action-primary-hover);
+  border-color: var(--color-action-primary-hover);
+}

--- a/front/src/css/loginform.css
+++ b/front/src/css/loginform.css
@@ -1,22 +1,43 @@
 .form-group label {
   font-size: 1.5rem;
   font-family: "Quicksand";
+  color: var(--color-text-secondary);
 }
 .form-group input {
   font-size: 1.5rem;
   font-family: "Quicksand";
+  background-color: var(--color-input-bg);
+  color: var(--color-input-text);
+  border: 1px solid var(--color-input-border);
 }
 .alert {
   font-size: 1.5rem;
   font-family: "Quicksand";
+  background-color: var(--color-status-danger);
+  color: var(--color-text-on-contrast);
 }
 
 .btn {
   font-size: 1.5rem;
   font-family: "Quicksand";
+  background-color: var(--color-action-primary-bg);
+  color: var(--color-action-primary-text);
+  border-color: var(--color-action-primary-bg);
 }
 
 .form-group button {
   font-size: 3rem;
   font-family: "Quicksand";
+  background-color: var(--color-action-primary-bg);
+  color: var(--color-action-primary-text);
+  border: 1px solid var(--color-action-primary-bg);
+}
+
+.btn:hover,
+.btn:focus,
+.form-group button:hover,
+.form-group button:focus {
+  background-color: var(--color-action-primary-hover);
+  border-color: var(--color-action-primary-hover);
+  color: var(--color-action-primary-text);
 }

--- a/front/src/css/modalcamion.css
+++ b/front/src/css/modalcamion.css
@@ -1,7 +1,7 @@
 #cantent {
-  color: red;
+  color: var(--color-status-danger);
 }
 
 #form-controlcantent {
-  color: red;
+  color: var(--color-status-danger);
 }

--- a/front/src/css/modalcomanda.css
+++ b/front/src/css/modalcomanda.css
@@ -1,15 +1,15 @@
 #estado {
-  color: red;
+  color: var(--color-status-danger);
 }
 
 #distribucion {
-  color: blue;
+  color: var(--color-status-info);
 }
 
 .actualizando{
-  color: red;
+  color: var(--color-status-danger);
 }
 
 .h4{
-  color: red;
+  color: var(--color-status-danger);
 }

--- a/front/src/css/navbar.css
+++ b/front/src/css/navbar.css
@@ -1,35 +1,37 @@
 .navBar-toggler {
-  color: #f5f5f5 !important;
-  background-color: #121212 !important;
-  border: 1px solid #3a3a3a !important;
+  color: var(--color-text-on-contrast) !important;
+  background-color: var(--color-surface-contrast) !important;
+  border: 1px solid var(--color-contrast-border) !important;
+  box-shadow: var(--shadow-contrast);
 }
 .navBar h4 {
   font-size: 1.75rem;
   text-align: center;
 
-  background-color: #121212 !important;
-  color: #f5f5f5 !important;
+  background-color: var(--color-surface-contrast) !important;
+  color: var(--color-text-on-contrast) !important;
   font-family: "Quicksand";
 }
 
 .navBar {
   /* background-color: black !important; */
-  background-color: #121212 !important;
-  color: #f5f5f5 !important;
+  background-color: var(--color-surface-contrast) !important;
+  color: var(--color-text-on-contrast) !important;
   font-size: 2rem;
   font-family: "Times New Roman", Times, serif;
   padding: 1rem;
+  box-shadow: var(--shadow-contrast);
 }
 
 .navBar-toggler:hover,
 .navBar-toggler:focus {
-  color: #e0e0e0 !important;
-  background-color: #1b1b1b !important;
-  border-color: #4a4a4a !important;
+  color: var(--color-text-on-contrast-muted) !important;
+  background-color: var(--color-surface-contrast-hover) !important;
+  border-color: var(--color-contrast-border-strong) !important;
   outline: none;
 }
 button #hamburguesa.navBar-toggler.collapsed{
-  background: #1b1b1b !important;
+  background: var(--color-surface-contrast-hover) !important;
 }
 .nav-link {
   font-family: "Quicksand";
@@ -39,12 +41,12 @@ button #hamburguesa.navBar-toggler.collapsed{
   display: inline;
   text-align: center;
   /* -webkit-margin-start: 2rem; */
-  color: #f5f5f5 !important;
+  color: var(--color-text-on-contrast) !important;
 }
 .nav-link:hover,
 .nav-link:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: var(--color-text-on-contrast-muted) !important;
+  background-color: var(--color-surface-contrast-active) !important;
   outline: none;
 }
 
@@ -57,7 +59,7 @@ button #hamburguesa.navBar-toggler.collapsed{
   text-align: center;
   -webkit-margin-start: 1rem;
   -webkit-margin-end: 1rem;
-  color: #f5f5f5 !important;
+  color: var(--color-text-on-contrast) !important;
   display: flex;
   justify-content: center;
   margin-top: 0.5rem;
@@ -67,27 +69,28 @@ button #hamburguesa.navBar-toggler.collapsed{
   font-family: "Quicksand";
   font-size: 1.5rem;
   /* background-color: black !important; */
-  background-color: #1b1b1b !important;
-  color: #f5f5f5 !important;
-  border: 1px solid #3a3a3a !important;
+  background-color: var(--color-surface-contrast-hover) !important;
+  color: var(--color-text-on-contrast) !important;
+  border: 1px solid var(--color-contrast-border) !important;
+  box-shadow: var(--shadow-soft);
 }
 
 .dropdown-item {
   font-family: "Quicksand";
   font-size: 1.5rem;
   /* background-color: black !important; */
-  background-color: #1b1b1b !important;
-  color: #f5f5f5 !important;
+  background-color: var(--color-surface-contrast-hover) !important;
+  color: var(--color-text-on-contrast) !important;
 }
 .dropdown-item:hover,
 .dropdown-item:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: var(--color-text-on-contrast-muted) !important;
+  background-color: var(--color-surface-contrast-active) !important;
 }
 
 .nav-link1 {
   font-family: "Quicksand";
-  color: #f5f5f5 !important;
+  color: var(--color-text-on-contrast) !important;
   margin-bottom: 10px;
   font-size: 1.75rem;
   display: inline;
@@ -97,14 +100,14 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 .nav-link1:hover,
 .nav-link1:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: var(--color-text-on-contrast-muted) !important;
+  background-color: var(--color-surface-contrast-active) !important;
   outline: none;
 }
 
 .nav-link3 {
   font-family: "Quicksand";
-  color: #f5f5f5 !important;
+  color: var(--color-text-on-contrast) !important;
   margin-bottom: 10px;
   font-size: 1.75rem;
   display: inline;
@@ -114,14 +117,14 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 .nav-link3:hover,
 .nav-link3:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: var(--color-text-on-contrast-muted) !important;
+  background-color: var(--color-surface-contrast-active) !important;
   outline: none;
 }
 
 .nav-link2 {
   font-family: "Quicksand";
-  color: #f5f5f5 !important;
+  color: var(--color-text-on-contrast) !important;
   margin-bottom: 10px;
   font-size: 1.75rem;
   display: inline;
@@ -133,18 +136,18 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 .nav-link2:hover,
 .nav-link2:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: var(--color-text-on-contrast-muted) !important;
+  background-color: var(--color-surface-contrast-active) !important;
   outline: none;
 }
 
 #navBar nav {
-  background-color: #121212 !important;
+  background-color: var(--color-surface-contrast) !important;
   /* background-color: black !important; */
   font-size: 1.75rem;
   display: flex;
   justify-content: center;
-  color: #f5f5f5 !important;
+  color: var(--color-text-on-contrast) !important;
 }
 
 .navBar img {
@@ -152,39 +155,39 @@ button #hamburguesa.navBar-toggler.collapsed{
   padding: 1rem;
   display: flex;
   justify-content: center;
-  color: #f5f5f5 !important;
+  color: var(--color-text-on-contrast) !important;
 }
 
 .navBar span {
-  background-color: #121212 !important;
+  background-color: var(--color-surface-contrast) !important;
   /* background-color: black !important; */
   font-size: 2.2rem;
-  color: #f5f5f5 !important;
+  color: var(--color-text-on-contrast) !important;
   font-family: "Times New Roman", Times, serif;
 }
 
 #booton {
   font-family: "Quicksand";
   font-size: 1.75rem;
-  color: #f5f5f5 !important;
-  background-color: #1b1b1b !important;
-  border: 1px solid #3a3a3a !important;
+  color: var(--color-text-on-contrast) !important;
+  background-color: var(--color-surface-contrast-hover) !important;
+  border: 1px solid var(--color-contrast-border) !important;
 }
 #booton:hover,
 #booton:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
-  border-color: #4a4a4a !important;
+  color: var(--color-text-on-contrast-muted) !important;
+  background-color: var(--color-surface-contrast-active) !important;
+  border-color: var(--color-contrast-border-strong) !important;
   outline: none;
 }
 
 #user {
   font-family: "Quicksand";
   font-size: 1.75rem;
-  color: #e0e0e0 !important;
+  color: var(--color-text-on-contrast-muted) !important;
 }
 #user:focus {
-  outline: 2px solid #4a4a4a;
+  outline: 2px solid var(--color-contrast-border-strong);
   outline-offset: 2px;
 }
 
@@ -254,7 +257,7 @@ button #hamburguesa.navBar-toggler.collapsed{
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #e0e0e0;
+    color: var(--color-text-on-contrast-muted);
   }
 }
 /* 
@@ -263,7 +266,7 @@ button #hamburguesa.navBar-toggler.collapsed{
       margin-left: 50%;
       margin-top: 10px;
       transform: translateX(130%);
-      background-color: red !important;
-      color: red !important;
+      background-color: var(--color-accent) !important;
+      color: var(--color-text-on-contrast) !important;
     }
   } */

--- a/front/src/css/principal.css
+++ b/front/src/css/principal.css
@@ -1,5 +1,5 @@
 div#root {
-  background-color: white;
+  background-color: var(--color-page-bg);
   /* background-color: #E9ECEF; */
   /* background-color: #20262E; */
   /* background-color: #FFFFFFDE; */
@@ -8,7 +8,7 @@ div#root {
 h2,
 h3,
 h4 {
-  color: black;
+  color: var(--color-text-primary);
 }
 
 hr {
@@ -16,7 +16,7 @@ hr {
 }
 
 /* .card {
-    color: #1d3557;
+    color: var(--color-text-secondary);
     width: 250px;
     border-radius: 10px;
     overflow: hidden;
@@ -36,7 +36,7 @@ hr {
 }
 
 .card span {
-  color: #1d3557;
+  color: var(--color-text-secondary);
   font-size: 1.5rem;
 }
 

--- a/front/src/css/propiedades.css
+++ b/front/src/css/propiedades.css
@@ -1,7 +1,7 @@
 .background-curso {
-  background-color: #051626;
+  background-color: var(--color-hero-bg);
   height: 100vh;
-  color: #ffff;
+  color: var(--color-text-on-contrast);
 }
 /* .avatar {
   border-radius: 100%;
@@ -14,11 +14,13 @@
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: center;
-  color: black;
+  color: var(--color-text-primary);
   width: 250px;
   border-radius: 10px;
   overflow: hidden;
   font-size: 0.25rem;
+  background-color: var(--color-surface);
+  box-shadow: var(--shadow-soft);
 }
 .card-img-top {
   height: 100px;
@@ -30,11 +32,11 @@
 }
 
 .buscando{
-  color:white
+  color: var(--color-text-on-contrast);
 }
 
 .card span {
-  color: white;
+  color: var(--color-card-highlight);
   font-size: 20px;
 }
 
@@ -43,6 +45,7 @@
     display: flex;
     justify-content: center;
     font-size: 1rem;
-    background-color: red;
+    background-color: var(--color-accent);
+    color: var(--color-text-on-contrast);
   }
 }

--- a/front/src/css/quienes.css
+++ b/front/src/css/quienes.css
@@ -3,11 +3,24 @@
   font-size: 1.75rem;
 }
 .col {
-  background-color: white;
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
+  box-shadow: var(--shadow-soft);
 }
 
 .btn.btn-dark {
   font-size: 1.5rem;
+  background-color: var(--color-action-primary-bg);
+  border-color: var(--color-action-primary-bg);
+  color: var(--color-action-primary-text);
+  transition: background-color 0.2s ease;
+}
+
+.btn.btn-dark:hover,
+.btn.btn-dark:focus {
+  background-color: var(--color-action-primary-hover);
+  border-color: var(--color-action-primary-hover);
+  color: var(--color-action-primary-text);
 }
 
 @media (max-width: 768px) {

--- a/front/src/css/tablecamion.css
+++ b/front/src/css/tablecamion.css
@@ -4,7 +4,8 @@
   overflow-x: scroll;
   overflow-y: scroll;
   font-size: 4rem;
-  background-color: #f1faee;
+  background-color: var(--color-surface-subtle);
+  color: var(--color-text-primary);
   /* margin-left: 0%;  */
 }
 
@@ -17,7 +18,8 @@
 
   /* background-color:#F1FAEE; */
 
-  color: white;
+  background-color: var(--color-table-header);
+  color: var(--color-table-header-text);
 }
 
 .sticky1 {
@@ -26,6 +28,8 @@
   /* background-color: #F1FAEE; */
   max-width: 60px;
   font-size: 2rem;
+  background-color: var(--color-table-header);
+  color: var(--color-table-header-text);
 }
 
 #acepto {
@@ -33,7 +37,18 @@
   height: 3rem;
   width: 3rem;
   font-size: 1.5rem;
-  color: white;
+  background-color: var(--color-action-primary-bg);
+  color: var(--color-action-primary-text);
+  border: 1px solid var(--color-action-primary-bg);
+  border-radius: 0.4rem;
+  transition: background-color 0.2s ease;
+}
+
+#acepto:hover,
+#acepto:focus {
+  background-color: var(--color-action-primary-hover);
+  border-color: var(--color-action-primary-hover);
+  color: var(--color-action-primary-text);
 }
 
 .cli {
@@ -49,8 +64,8 @@
   width: 336px;
   /* margin-right: 1px; */
   font-size: 1.25rem;
-  background-color: rgb(23, 23, 87);
-  color:white;
+  background-color: var(--color-action-primary-bg);
+  color: var(--color-action-primary-text);
 }
 
 .botones1 {
@@ -58,8 +73,8 @@
   width: 336px;
   /* margin-right: 1px; */
   font-size: 1.25rem;
-  background-color: rgb(23, 23, 87);
-  color: black;
+  background-color: var(--color-action-primary-bg);
+  color: var(--color-action-primary-text);
 }
 
 .button.botones {
@@ -67,8 +82,8 @@
   max-width: 330px;
   margin-right: 1px;
   font-size: 1.25rem;
-  background-color: rgb(23, 23, 87);
-  color: rgb(22, 23, 23);
+  background-color: var(--color-action-primary-bg);
+  color: var(--color-action-primary-text);
 }
 
 .pie {

--- a/front/src/css/tableclientes.css
+++ b/front/src/css/tableclientes.css
@@ -4,14 +4,17 @@
   overflow-x: scroll;
   overflow-y: scroll;
   font-size: 1.25rem;
+  background-color: var(--color-surface-subtle);
+  color: var(--color-text-primary);
 
   /* margin-left: 0%;  */
 }
 
 .header {
   top: 0;
-  box-shadow: 0px 3px 3px #ccc;
-  background-color: rgb(114, 155, 179);
+  box-shadow: var(--shadow-soft);
+  background-color: var(--color-table-header);
+  color: var(--color-table-header-text);
   position: sticky;
   z-index: 10;
 }
@@ -30,7 +33,8 @@
   max-width: 60px;
   font-size: 1.5rem;
   font-size: 1.25rem;
-  background-color: rgb(114, 155, 179);
+  background-color: var(--color-table-header);
+  color: var(--color-table-header-text);
 }
 
 #acepto {
@@ -38,6 +42,18 @@
   height: 3rem;
   width: 3rem;
   font-size: 1.5rem;
+  background-color: var(--color-action-primary-bg);
+  color: var(--color-action-primary-text);
+  border: 1px solid var(--color-action-primary-bg);
+  border-radius: 0.4rem;
+  transition: background-color 0.2s ease;
+}
+
+#acepto:hover,
+#acepto:focus {
+  background-color: var(--color-action-primary-hover);
+  border-color: var(--color-action-primary-hover);
+  color: var(--color-action-primary-text);
 }
 
 .cli {

--- a/front/src/css/tablecomandas.css
+++ b/front/src/css/tablecomandas.css
@@ -4,7 +4,8 @@
   overflow-x: scroll;
   overflow-y: scroll;
   font-size: 4rem;
-  background-color: #f1faee;
+  background-color: var(--color-surface-subtle);
+  color: var(--color-text-primary);
   /* margin-left: 0%;  */
 }
 
@@ -17,7 +18,8 @@
 
   /* background-color:#F1FAEE; */
 
-  color: white;
+  background-color: var(--color-table-header);
+  color: var(--color-table-header-text);
 }
 
 .sticky1 {
@@ -26,6 +28,8 @@
   /* background-color: #F1FAEE; */
   max-width: 60px;
   font-size: 2rem;
+  background-color: var(--color-table-header);
+  color: var(--color-table-header-text);
 }
 
 #acepto {
@@ -33,7 +37,18 @@
   height: 3rem;
   width: 3rem;
   font-size: 1.5rem;
-  color: white;
+  background-color: var(--color-action-primary-bg);
+  color: var(--color-action-primary-text);
+  border: 1px solid var(--color-action-primary-bg);
+  border-radius: 0.4rem;
+  transition: background-color 0.2s ease;
+}
+
+#acepto:hover,
+#acepto:focus {
+  background-color: var(--color-action-primary-hover);
+  border-color: var(--color-action-primary-hover);
+  color: var(--color-action-primary-text);
 }
 
 .cli {
@@ -49,8 +64,8 @@
   max-width: 330px;
   margin-right: 1px;
   font-size: 1.25rem;
-  background-color: rgb(23, 23, 87);
-  color: white;
+  background-color: var(--color-action-primary-bg);
+  color: var(--color-action-primary-text);
 }
 
 .pie {
@@ -63,7 +78,7 @@
   font-size: 1.75rem;
   text-align-last: right;
   text-align: right;
-  color: red;
+  color: var(--color-status-danger);
 }
 .button.botones {
   height: 35px;
@@ -71,6 +86,6 @@
   margin-right: 1px;
   font-size: 1.25rem;
   /* background-color: white; */
-  background-color: rgb(23, 23, 87);
-  color:black;
+  background-color: var(--color-action-primary-bg);
+  color: var(--color-action-primary-text);
 }

--- a/front/src/css/tableproducservs.css
+++ b/front/src/css/tableproducservs.css
@@ -4,14 +4,17 @@
   overflow-x: scroll;
   overflow-y: scroll;
   font-size: 1.25rem;
+  background-color: var(--color-surface-subtle);
+  color: var(--color-text-primary);
 
   /* margin-left: 0%;  */
 }
 
 .header {
   top: 0;
-  box-shadow: 0px 3px 3px #ccc;
-  background-color: rgb(114, 155, 179);
+  box-shadow: var(--shadow-soft);
+  background-color: var(--color-table-header);
+  color: var(--color-table-header-text);
   position: sticky;
   z-index: 10;
 }
@@ -29,7 +32,8 @@
   left: 0;
   max-width: 60px;
   font-size: 1.25rem;
-  background-color: rgb(114, 155, 179);
+  background-color: var(--color-table-header);
+  color: var(--color-table-header-text);
 }
 
 #acepto {
@@ -37,6 +41,18 @@
   height: 3rem;
   width: 3rem;
   font-size: 1.5rem;
+  background-color: var(--color-action-primary-bg);
+  color: var(--color-action-primary-text);
+  border: 1px solid var(--color-action-primary-bg);
+  border-radius: 0.4rem;
+  transition: background-color 0.2s ease;
+}
+
+#acepto:hover,
+#acepto:focus {
+  background-color: var(--color-action-primary-hover);
+  border-color: var(--color-action-primary-hover);
+  color: var(--color-action-primary-text);
 }
 
 .cli {

--- a/front/src/css/tableproveedores.css
+++ b/front/src/css/tableproveedores.css
@@ -4,14 +4,17 @@
   overflow-x: scroll;
   overflow-y: scroll;
   font-size: 1.25rem;
+  background-color: var(--color-surface-subtle);
+  color: var(--color-text-primary);
 
   /* margin-left: 0%;  */
 }
 
 .header {
   top: 0;
-  box-shadow: 0px 3px 3px #ccc;
-  background-color: rgb(114, 155, 179);
+  box-shadow: var(--shadow-soft);
+  background-color: var(--color-table-header);
+  color: var(--color-table-header-text);
   position: sticky;
   z-index: 10;
 }
@@ -30,7 +33,8 @@
   max-width: 60px;
   font-size: 1.5rem;
   font-size: 1.25rem;
-  background-color: rgb(114, 155, 179);
+  background-color: var(--color-table-header);
+  color: var(--color-table-header-text);
 }
 
 #acepto {
@@ -38,6 +42,18 @@
   height: 3rem;
   width: 3rem;
   font-size: 1.5rem;
+  background-color: var(--color-action-primary-bg);
+  color: var(--color-action-primary-text);
+  border: 1px solid var(--color-action-primary-bg);
+  border-radius: 0.4rem;
+  transition: background-color 0.2s ease;
+}
+
+#acepto:hover,
+#acepto:focus {
+  background-color: var(--color-action-primary-hover);
+  border-color: var(--color-action-primary-hover);
+  color: var(--color-action-primary-text);
 }
 
 .cli {

--- a/front/src/css/tablerutas.css
+++ b/front/src/css/tablerutas.css
@@ -5,14 +5,17 @@
   overflow-x: scroll;
   overflow-y: scroll;
   font-size: 1.25rem;
+  background-color: var(--color-surface-subtle);
+  color: var(--color-text-primary);
 
   /* margin-left: 0%;  */
 }
 
 .header {
   top: 0;
-  box-shadow: 0px 3px 3px #ccc;
-  background-color: rgb(114, 155, 179);
+  box-shadow: var(--shadow-soft);
+  background-color: var(--color-table-header);
+  color: var(--color-table-header-text);
   position: sticky;
   z-index: 10;
 }
@@ -31,7 +34,8 @@
   max-width: 50px;
   font-size: 1.5rem;
   font-size: 1.25rem;
-  background-color: rgb(114, 155, 179);
+  background-color: var(--color-table-header);
+  color: var(--color-table-header-text);
 
 }
 
@@ -40,6 +44,18 @@
   height: 3rem;
   width: 3rem;
   font-size: 1.5rem;
+  background-color: var(--color-action-primary-bg);
+  color: var(--color-action-primary-text);
+  border: 1px solid var(--color-action-primary-bg);
+  border-radius: 0.4rem;
+  transition: background-color 0.2s ease;
+}
+
+#acepto:hover,
+#acepto:focus {
+  background-color: var(--color-action-primary-hover);
+  border-color: var(--color-action-primary-hover);
+  color: var(--color-action-primary-text);
 }
 
 .cli {

--- a/front/src/helpers/theme.js
+++ b/front/src/helpers/theme.js
@@ -1,0 +1,11 @@
+export const getCssVariable = (variableName, fallback = "") => {
+  if (typeof window === "undefined" || !window.document) {
+    return fallback;
+  }
+
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(variableName)
+    .trim();
+
+  return value || fallback;
+};

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -1,9 +1,117 @@
 html {
-    font-size: 62.5%;
-  }
-  
-  body #root {
-    font-family: "Quicksand";
-    background-color: #f1faee;
-  }
+  font-size: 62.5%;
+}
+
+:root,
+:root[data-theme="light"] {
+  color-scheme: light;
+  --color-page-bg: #f1faee;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f6f9fc;
+  --color-surface-subtle: #f1faee;
+  --color-surface-contrast: #1d3557;
+  --color-surface-contrast-hover: #274c77;
+  --color-surface-contrast-active: #16324f;
+
+  --color-text-primary: #1b263b;
+  --color-text-secondary: #415a77;
+  --color-text-muted: #5c6f82;
+  --color-text-on-contrast: #f1faee;
+  --color-text-on-contrast-muted: #e0e0e0;
+
+  --color-border: #cbd5e1;
+  --color-border-strong: #9aa6b2;
+  --color-contrast-border: #26406f;
+  --color-contrast-border-strong: #0b2545;
+
+  --color-accent: #e63946;
+  --color-accent-strong: #ba1b26;
+  --color-status-danger: #ba1b26;
+  --color-status-success: #4caf50;
+  --color-status-info: #548fcd;
+  --color-status-highlight: #2ec4b6;
+
+  --color-input-bg: #ffffff;
+  --color-input-border: #9aa6b2;
+  --color-input-text: #1b263b;
+
+  --color-table-header: #729bb3;
+  --color-table-header-text: #0b132b;
+  --color-table-row-hover: rgba(29, 53, 87, 0.08);
+
+  --color-hero-bg: #051626;
+  --color-card-highlight: #274c77;
+
+  --color-action-primary-bg: #1d3557;
+  --color-action-primary-hover: #274c77;
+  --color-action-primary-text: #f1faee;
+
+  --color-overlay-soft: rgba(17, 24, 39, 0.2);
+  --color-overlay-strong: rgba(17, 24, 39, 0.45);
+
+  --shadow-soft: 0 3px 8px rgba(15, 23, 42, 0.12);
+  --shadow-contrast: 0 4px 12px rgba(15, 23, 42, 0.2);
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --color-page-bg: #0b0e14;
+  --color-surface: #121720;
+  --color-surface-muted: #161d2a;
+  --color-surface-subtle: #121720;
+  --color-surface-contrast: #121212;
+  --color-surface-contrast-hover: #1f1f1f;
+  --color-surface-contrast-active: #2a2a2a;
+
+  --color-text-primary: #f5f5f5;
+  --color-text-secondary: #d1d5f0;
+  --color-text-muted: #b0b8c8;
+  --color-text-on-contrast: #f5f5f5;
+  --color-text-on-contrast-muted: #d1d5db;
+
+  --color-border: #2a3244;
+  --color-border-strong: #39445a;
+  --color-contrast-border: #2d2d2d;
+  --color-contrast-border-strong: #3a3a3a;
+
+  --color-accent: #ef476f;
+  --color-accent-strong: #ff5d88;
+  --color-status-danger: #ff5d88;
+  --color-status-success: #5ad669;
+  --color-status-info: #5aa0ef;
+  --color-status-highlight: #2dd4bf;
+
+  --color-input-bg: #121720;
+  --color-input-border: #39445a;
+  --color-input-text: #f5f5f5;
+
+  --color-table-header: #24324a;
+  --color-table-header-text: #f1f5ff;
+  --color-table-row-hover: rgba(148, 163, 184, 0.18);
+
+  --color-hero-bg: #030a14;
+  --color-card-highlight: #2a6f97;
+
+  --color-action-primary-bg: #2a6f97;
+  --color-action-primary-hover: #3b82c4;
+  --color-action-primary-text: #f5f5f5;
+
+  --color-overlay-soft: rgba(10, 12, 16, 0.45);
+  --color-overlay-strong: rgba(10, 12, 16, 0.7);
+
+  --shadow-soft: 0 4px 12px rgba(0, 0, 0, 0.4);
+  --shadow-contrast: 0 6px 18px rgba(0, 0, 0, 0.55);
+}
+
+body {
+  font-family: "Quicksand", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  background-color: var(--color-page-bg);
+  color: var(--color-text-primary);
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+body #root {
+  background-color: var(--color-page-bg);
+}
   

--- a/front/src/table/AppCamionReactTable.js
+++ b/front/src/table/AppCamionReactTable.js
@@ -5,6 +5,7 @@ import axios from "axios";
 import _ from "lodash";
 import Table from "./TableContainerCamion";
 import ModalCamion from "../components/ModalCamion";
+import { getCssVariable } from "../helpers/theme";
 var arrayComandas = [];
 
 function AppCamionReactTable() {
@@ -15,6 +16,7 @@ function AppCamionReactTable() {
   });
   const [comanda, setComanda] = useState({});
   const [data, setData] = useState([]);
+  const contrastText = getCssVariable("--color-text-on-contrast", "#f5f5f5");
 
   var iduser = localStorage.getItem("id");
   useEffect(() => {
@@ -33,34 +35,35 @@ function AppCamionReactTable() {
     sticky: true;
     padding: 0rem;
 
-    table {
+  table {
+    sticky: true;
+    color: var(--color-text-primary);
+    background-color: var(--color-surface-subtle);
+    border-spacing: 0;
+    border: 1px solid var(--color-border-strong);
+    font-size: 13px;
+    z-index: 10;
+
+    th {
       sticky: true;
-      color: black;
-      background-color: #f1faee;
-      border-spacing: 0;
-      border: 1px solid black;
-      font-size: 13px;
-      z-index: 10;
-     
-      th {
-        sticky: true;
-        background-color: #548fcd;
-        font-size: 12px;
-        text-align: center;
-        height: 10rem;
-        position: sticky;
+      background-color: var(--color-status-info);
+      font-size: 12px;
+      text-align: center;
+      height: 10rem;
+      position: sticky;
+          color: var(--color-text-on-contrast);
             // top: 100;
             z-index: -1;
-      }
-      ,
-      td {
-        // sticky: true;
-        margin: 0;
-        padding: 0.5rem;
-        border-bottom: 1px solid black;
-        border-right: 1px solid black;
-        background-color: #f0f2eb;
-        font-size: 13px;
+    }
+    ,
+    td {
+      // sticky: true;
+      margin: 0;
+      padding: 0.5rem;
+      border-bottom: 1px solid var(--color-border);
+      border-right: 1px solid var(--color-border);
+      background-color: var(--color-surface-muted);
+      font-size: 13px;
 
         :last-child {
           border-right: 0;
@@ -76,12 +79,13 @@ function AppCamionReactTable() {
       }
     }
 
-    .pagination {
-      padding: 0.5rem;
-      background-color: #548fcd;
-      font-size: 15px;
-      font-weight: bold;
-    }
+  .pagination {
+    padding: 0.5rem;
+    background-color: var(--color-status-info);
+    color: var(--color-text-on-contrast);
+    font-size: 15px;
+    font-weight: bold;
+  }
 
     &.sticky {
       overflow: scroll;
@@ -93,13 +97,13 @@ function AppCamionReactTable() {
       }
     }
 
-    .header {
-      top: 0;
-      box-shadow: 0px 3px 3px #ccc;
-      position: sticky;
-      z-index: 10;
-      
-    }
+  .header {
+    top: 0;
+    box-shadow: var(--shadow-soft);
+    position: sticky;
+    z-index: 10;
+
+  }
 
     [data-sticky-td] {
       position: sticky;
@@ -367,7 +371,7 @@ function AppCamionReactTable() {
             <i
               className="fa fa-pencil-square-o"
               aria-hidden="true"
-              color="white"
+              style={{ color: contrastText }}
             ></i>
           </button>
         </div>

--- a/front/src/table/AppComandaReactTable.js
+++ b/front/src/table/AppComandaReactTable.js
@@ -9,6 +9,7 @@ import Table from "./TableContainer";
 import ModalComanda from "../components/ModalComanda";
 import ModalAsignar from "../components/ModalAsignar";
 import "../css/tablecomandas.css";
+import { getCssVariable } from "../helpers/theme";
 
 // import "./App.css";
 
@@ -23,6 +24,20 @@ function AppComandaReactTable() {
   });
   const [comanda, setComanda] = useState({});
   const [data, setData] = useState([]);
+  const dangerColor = getCssVariable("--color-status-danger", "#ba1b26");
+  const contrastText = getCssVariable("--color-text-on-contrast", "#f5f5f5");
+  const currencyFormatter = React.useMemo(
+    () =>
+      new Intl.NumberFormat("es-AR", {
+        style: "currency",
+        currency: "ARS",
+      }),
+    []
+  );
+
+  const renderCurrency = (value) => (
+    <span style={{ color: dangerColor }}>{currencyFormatter.format(value)}</span>
+  );
 
   useEffect(() => {
     axios("http://localhost:3004/comandasactivas")
@@ -39,19 +54,20 @@ function AppComandaReactTable() {
     table {
       sticky: true;
       // background-color: #548fcd;
-      color: black;
+      color: var(--color-text-primary);
       border-spacing: 0;
-      border: 1px solid black;
+      border: 1px solid var(--color-border-strong);
       font-size: 13px;
       z-index: 1;
 
       th {
         sticky: true;
-        background-color: #548fcd;
+        background-color: var(--color-status-info);
         font-size: 12px;
         text-align: center;
         height: 10rem;
         // position: sticky;
+        color: var(--color-text-on-contrast);
         top: 100;
         z-index: 1;
       }
@@ -60,10 +76,10 @@ function AppComandaReactTable() {
         sticky: true;
         margin: 0;
         padding: 0.5rem;
-        border-bottom: 1px solid black;
-        border-right: 1px solid black;
+        border-bottom: 1px solid var(--color-border);
+        border-right: 1px solid var(--color-border);
         // background-color: #548f0a;
-        background-color: #f0f2eb;
+        background-color: var(--color-surface-muted);
         font-size: 13px;
         // top: 100;
         // z-index: 1;
@@ -84,7 +100,8 @@ function AppComandaReactTable() {
 
     .pagination {
       padding: 0.5rem;
-      background-color: #548fcd;
+      background-color: var(--color-status-info);
+      color: var(--color-text-on-contrast);
       font-size: 15px;
       font-weight: bold;
     }
@@ -101,7 +118,7 @@ function AppComandaReactTable() {
 
     .header {
       top: 0;
-      box-shadow: 0px 3px 3px #ccc;
+      box-shadow: var(--shadow-soft);
       position: sticky;
       z-index: 10;
     }
@@ -461,11 +478,7 @@ function AppComandaReactTable() {
       width: "150",
       accessor: (d) => `${d.cantidad}` * `${d.monto}`,
 
-      Cell: (props) =>
-        new Intl.NumberFormat("es-AR", {
-          style: "currency",
-          currency: "ARS",
-        }).format(props.value),
+      Cell: (props) => renderCurrency(props.value),
       Footer: (info) => {
         const total = React.useMemo(
           () => info.rows.reduce((sum, row) => row.values.total + sum, 0),
@@ -510,23 +523,15 @@ function AppComandaReactTable() {
         );
 
         return (
-          <div className= "pie1" style={{ textAlign: "right" }}>
-            {new Intl.NumberFormat("es-AR", {
-              style: "currency",
-              currency: "ARS",
-              color: "red",
-            }).format(totalentregada)}
+          <div className="pie1" style={{ textAlign: "right" }}>
+            {renderCurrency(totalentregada)}
           </div>
         );
       },
 
       Cell: (row) => (
         <div style={{ textAlign: "right" }}>
-          {new Intl.NumberFormat("es-AR", {
-            style: "currency",
-            currency: "ARS",
-            color: "red",
-          }).format(row.value)}
+          {renderCurrency(row.value)}
         </div>
       ),
     },
@@ -589,7 +594,11 @@ function AppComandaReactTable() {
               )
             }
           >
-            <i className="fa fa-truck" aria-hidden="true" color="white"></i>
+            <i
+              className="fa fa-truck"
+              aria-hidden="true"
+              style={{ color: contrastText }}
+            ></i>
           </button>
         </div>
       ),
@@ -609,7 +618,7 @@ function AppComandaReactTable() {
             <i
               className="fa fa-pencil-square-o"
               aria-hidden="true"
-              color="white"
+              style={{ color: contrastText }}
             ></i>
           </button>
         </div>
@@ -637,7 +646,11 @@ function AppComandaReactTable() {
             className="btn btn-danger"
             onClick={(e) => deleteComanda(row.row.original.nrodecomanda)}
           >
-            <i className="fa fa-trash-o" aria-hidden="true" color="white"></i>
+            <i
+              className="fa fa-trash-o"
+              aria-hidden="true"
+              style={{ color: contrastText }}
+            ></i>
           </button>
         </div>
       ),

--- a/front/src/table/AppGestionReactTable.js
+++ b/front/src/table/AppGestionReactTable.js
@@ -8,6 +8,7 @@ import Table from "./TableContainer";
 import ModalComanda from "../components/ModalComanda";
 import ModalAsignar from "../components/ModalAsignar";
 import "../css/tablecomandas.css";
+import { getCssVariable } from "../helpers/theme";
 
 
 function AppGestionReactTable() {
@@ -20,6 +21,20 @@ function AppGestionReactTable() {
     data: {},
     loading: true,
   });
+  const dangerColor = getCssVariable("--color-status-danger", "#ba1b26");
+  const contrastText = getCssVariable("--color-text-on-contrast", "#f5f5f5");
+  const currencyFormatter = React.useMemo(
+    () =>
+      new Intl.NumberFormat("es-AR", {
+        style: "currency",
+        currency: "ARS",
+      }),
+    []
+  );
+
+  const renderCurrency = (value) => (
+    <span style={{ color: dangerColor }}>{currencyFormatter.format(value)}</span>
+  );
   const [comanda, setComanda] = useState({});
   const [data, setData] = useState([]);
   const [carga, setCarga] = useState(false);
@@ -63,19 +78,20 @@ function AppGestionReactTable() {
 
     table {
       sticky: true;
-      color: black;
+      color: var(--color-text-primary);
       border-spacing: 0;
-      border: 1px solid black;
+      border: 1px solid var(--color-border-strong);
       font-size: 13px;
       z-index: 1;
 
       th {
         sticky: true;
-        background-color: #607d8b;
+        background-color: var(--color-status-info);
         font-size: 12px;
         text-align: center;
         height: 10rem;
         // position: sticky;
+        color: var(--color-text-on-contrast);
         top: 100;
         z-index: 1;
       }
@@ -84,9 +100,9 @@ function AppGestionReactTable() {
         sticky: true;
         margin: 0;
         padding: 0.5rem;
-        border-bottom: 1px solid black;
-        border-right: 1px solid black;
-        background-color: #d6d2b3;
+        border-bottom: 1px solid var(--color-border);
+        border-right: 1px solid var(--color-border);
+        background-color: var(--color-surface-muted);
         font-size: 13px;
         // top: 100;
         // z-index: 1;
@@ -107,7 +123,8 @@ function AppGestionReactTable() {
 
     .pagination {
       padding: 0.5rem;
-      background-color: #607d8b;
+      background-color: var(--color-status-info);
+      color: var(--color-text-on-contrast);
       font-size: 15px;
       font-weight: bold;
     }
@@ -124,7 +141,7 @@ function AppGestionReactTable() {
 
     .header {
       top: 0;
-      box-shadow: 0px 3px 3px #ccc;
+      box-shadow: var(--shadow-soft);
       position: sticky;
       z-index: 10;
     }
@@ -456,22 +473,14 @@ const deleteComanda = async (nrodecomanda) => {
 
         return (
           <div className="pie1" style={{ textAlign: "right" }}>
-            {new Intl.NumberFormat("es-AR", {
-              style: "currency",
-              currency: "ARS",
-              color: "red",
-            }).format(totalentregada)}
+            {renderCurrency(totalentregada)}
           </div>
         );
       },
 
       Cell: (row) => (
         <div style={{ textAlign: "right" }}>
-          {new Intl.NumberFormat("es-AR", {
-            style: "currency",
-            currency: "ARS",
-            color: "red",
-          }).format(row.value)}
+          {renderCurrency(row.value)}
         </div>
       ),
     },
@@ -519,7 +528,7 @@ const deleteComanda = async (nrodecomanda) => {
             <i
               className="fa fa-pencil-square-o"
               aria-hidden="true"
-              color="white"
+              style={{ color: contrastText }}
             ></i>
           </button>
         </div>
@@ -548,7 +557,11 @@ const deleteComanda = async (nrodecomanda) => {
             className="btn btn-danger"
             onClick={(e) => deleteComanda(row.row.original.nrodecomanda)}
           >
-            <i className="fa fa-trash-o" aria-hidden="true" color="white"></i>
+            <i
+              className="fa fa-trash-o"
+              aria-hidden="true"
+              style={{ color: contrastText }}
+            ></i>
           </button>
         </div>
       ),

--- a/front/src/table/AppHojaRutaReactTable.js
+++ b/front/src/table/AppHojaRutaReactTable.js
@@ -5,6 +5,7 @@ import axios from "axios";
 import _ from "lodash";
 import Table from "./TableContainerOrden";
 import "../css/tablecamion.css";
+import { getCssVariable } from "../helpers/theme";
 // import { SelectColumnFilter } from "./Filter";
 // import "./App.css";
 function AppHojaRutaReactTable() {
@@ -17,6 +18,11 @@ function AppHojaRutaReactTable() {
       .catch((err) => console.log(err));
   }, []);
 
+  const dangerColor = getCssVariable("--color-status-danger", "#ba1b26");
+  const accentColor = getCssVariable("--color-accent", "#e63946");
+  const contrastText = getCssVariable("--color-text-on-contrast", "#f5f5f5");
+  const infoColor = getCssVariable("--color-status-info", "#548fcd");
+
   
   const Styles = styled.div`
   sticky: true;  
@@ -26,20 +32,20 @@ function AppHojaRutaReactTable() {
     sticky: true;
     // background-color: white;
     // background-color: #548fcd;
-    color: black;
+    color: var(--color-text-primary);
     border-spacing: 0;
-    border: 1px solid black;
+    border: 1px solid var(--color-border-strong);
     font-size: 13px;
     z-index: 1;
 
     th {
       sticky: true;
-      background-color: #8BC34A;
+      background-color: var(--color-status-success);
       font-size: 1.5rem;
       text-align: center;
       height: 4rem;
       // position: sticky;
-      color: black;
+      color: var(--color-text-on-contrast);
       top: 100;
       z-index: 1;
     }
@@ -48,10 +54,10 @@ function AppHojaRutaReactTable() {
       sticky: true;
       margin: 0;
       padding: 0.5rem;
-      border-bottom: 1px solid black;
-      border-right: 1px solid black;
+      border-bottom: 1px solid var(--color-border);
+      border-right: 1px solid var(--color-border);
       // background-color: #548f0a;
-      background-color: #f0f2eb;
+      background-color: var(--color-surface-muted);
       font-size: 13px;
       // top: 100;
       // z-index: 1;
@@ -73,7 +79,8 @@ function AppHojaRutaReactTable() {
 
   .pagination {
     padding: 0.5rem;
-    background-color: #548fcd;
+    background-color: var(--color-status-info);
+    color: var(--color-text-on-contrast);
     font-size: 15px;
     font-weight: bold;
   }
@@ -91,10 +98,10 @@ function AppHojaRutaReactTable() {
     .header {
       font-size: 13px;
       top: 0;
-      box-shadow: 0px 3px 3px #ccc;
+      box-shadow: var(--shadow-soft);
       position: sticky;
       z-index:10;
-      
+
     }
 
     [data-sticky-td] {
@@ -200,13 +207,13 @@ function AppHojaRutaReactTable() {
     {
       Header: "Camion",
       accessor: "camion.camion",
-      color: "red",
+      color: dangerColor,
       with: "200rem",
     },
     {
       Header: "Ruta",
       accessor: "codcli.ruta.ruta",
-      color: "red",
+      color: dangerColor,
       with: "200rem",
     },
     {
@@ -216,23 +223,23 @@ function AppHojaRutaReactTable() {
       style: {
         width: "100px",
         marginRight: "0.5rem",
-        color: "white",
+        color: contrastText,
       },
-      color: "red",
+      color: dangerColor,
       Cell: (row) => <div style={{ textAlign: "center" }}>{row.value}</div>,
     },
     {
       Header: "Clientes",
       accessor: "codcli.razonsocial",
-      background: "red",
-      color: "red",
+      background: accentColor,
+      color: dangerColor,
       width: "20em",
       margin: "2em",
     },
     {
       Header: "Productos",
       accessor: "codprod.descripcion",
-      color: "red",
+      color: dangerColor,
       with: "200rem",
     },
     // {
@@ -250,7 +257,7 @@ function AppHojaRutaReactTable() {
         marginRight: "0.5rem",
         
       },
-      color:"blue",
+      color: infoColor,
       // Cell: (row) => <div style={{ textAlign: "center" }}>{row.value}</div>,
       aggregate: "sum",
       Aggregated: ({ value }) => `${value} Cantidad(es)`,

--- a/front/src/table/AppImpresionReactTable.js
+++ b/front/src/table/AppImpresionReactTable.js
@@ -9,6 +9,7 @@ import Table from "./TableContainer";
 import ModalComanda from "../components/ModalComanda";
 import ModalAsignar from "../components/ModalAsignar";
 import "../css/tablecomandas.css";
+import { getCssVariable } from "../helpers/theme";
 
 // import "./App.css";
 
@@ -21,6 +22,19 @@ function AppImpresionReactTable() {
     data: {},
     loading: true,
   });
+  const dangerColor = getCssVariable("--color-status-danger", "#ba1b26");
+  const currencyFormatter = React.useMemo(
+    () =>
+      new Intl.NumberFormat("es-AR", {
+        style: "currency",
+        currency: "ARS",
+      }),
+    []
+  );
+
+  const renderCurrency = (value) => (
+    <span style={{ color: dangerColor }}>{currencyFormatter.format(value)}</span>
+  );
   const [comanda, setComanda] = useState({});
   const [data, setData] = useState([]);
 
@@ -39,19 +53,20 @@ function AppImpresionReactTable() {
     table {
       sticky: true;
       // background-color: #E7D583  ;
-      color: black;
+      color: var(--color-text-primary);
       border-spacing: 0;
-      border: 1px solid black;
+      border: 1px solid var(--color-border-strong);
       font-size: 13px;
       z-index: 1;
 
       th {
         sticky: true;
-        background-color: #E7D583  ;
+        background-color: var(--color-status-highlight);
         font-size: 12px;
         text-align: center;
         height: 10rem;
         // position: sticky;
+        color: var(--color-text-on-contrast);
         top: 100;
         z-index: 1;
       }
@@ -60,10 +75,10 @@ function AppImpresionReactTable() {
         sticky: true;
         margin: 0;
         padding: 0.5rem;
-        border-bottom: 1px solid black;
-        border-right: 1px solid black;
+        border-bottom: 1px solid var(--color-border);
+        border-right: 1px solid var(--color-border);
         // background-color: #548f0a;
-        background-color: #f0f2eb;
+        background-color: var(--color-surface-muted);
         font-size: 13px;
         // top: 100;
         // z-index: 1;
@@ -84,7 +99,8 @@ function AppImpresionReactTable() {
 
     .pagination {
       padding: 0.5rem;
-      background-color: #E7D583  ;
+      background-color: var(--color-status-highlight);
+      color: var(--color-text-on-contrast);
       font-size: 15px;
       font-weight: bold;
     }
@@ -101,7 +117,7 @@ function AppImpresionReactTable() {
 
     .header {
       top: 0;
-      box-shadow: 0px 3px 3px #ccc;
+      box-shadow: var(--shadow-soft);
       position: sticky;
       z-index: 10;
     }
@@ -461,11 +477,7 @@ function AppImpresionReactTable() {
       width: "150",
       accessor: (d) => `${d.cantidad}` * `${d.monto}`,
 
-      Cell: (props) =>
-        new Intl.NumberFormat("es-AR", {
-          style: "currency",
-          currency: "ARS",
-        }).format(props.value),
+      Cell: (props) => renderCurrency(props.value),
       Footer: (info) => {
         const total = React.useMemo(
           () => info.rows.reduce((sum, row) => row.values.total + sum, 0),
@@ -510,23 +522,15 @@ function AppImpresionReactTable() {
         );
 
         return (
-          <div className= "pie1" style={{ textAlign: "right" }}>
-            {new Intl.NumberFormat("es-AR", {
-              style: "currency",
-              currency: "ARS",
-              color: "red",
-            }).format(totalentregada)}
+          <div className="pie1" style={{ textAlign: "right" }}>
+            {renderCurrency(totalentregada)}
           </div>
         );
       },
 
       Cell: (row) => (
         <div style={{ textAlign: "right" }}>
-          {new Intl.NumberFormat("es-AR", {
-            style: "currency",
-            currency: "ARS",
-            color: "red",
-          }).format(row.value)}
+          {renderCurrency(row.value)}
         </div>
       ),
     },

--- a/front/src/table/AppMovStockReactTable.js
+++ b/front/src/table/AppMovStockReactTable.js
@@ -39,19 +39,20 @@ function AppMovStockReactTable() {
   table {
     sticky: true;
     // background-color: #548fcd;
-    color: black;
+    color: var(--color-text-primary);
     border-spacing: 0;
-    border: 1px solid black;
+    border: 1px solid var(--color-border-strong);
     font-size: 13px;
     z-index: 1;
 
     th {
       sticky: true;
-      background-color: #548fcd;
+      background-color: var(--color-status-info);
       font-size: 12px;
       text-align: center;
       height: 10rem;
       // position: sticky;
+      color: var(--color-text-on-contrast);
       top: 100;
       z-index: 1;
     }
@@ -60,10 +61,10 @@ function AppMovStockReactTable() {
       sticky: true;
       margin: 0;
       padding: 0.5rem;
-      border-bottom: 1px solid black;
-      border-right: 1px solid black;
+      border-bottom: 1px solid var(--color-border);
+      border-right: 1px solid var(--color-border);
       // background-color: #548f0a;
-      background-color: #f0f2eb;
+      background-color: var(--color-surface-muted);
       font-size: 13px;
       // top: 100;
       // z-index: 1;
@@ -85,7 +86,8 @@ function AppMovStockReactTable() {
 
   .pagination {
     padding: 0.5rem;
-    background-color: #548fcd;
+    background-color: var(--color-status-info);
+    color: var(--color-text-on-contrast);
     font-size: 15px;
     font-weight: bold;
   }
@@ -102,10 +104,10 @@ function AppMovStockReactTable() {
     
     .header {
       top: 0;
-      box-shadow: 0px 3px 3px #ccc;
+      box-shadow: var(--shadow-soft);
       position: sticky;
       z-index:10;
-      
+
     }
 
     [data-sticky-td] {

--- a/front/src/table/AppOrdenAPrepararReactTable.js
+++ b/front/src/table/AppOrdenAPrepararReactTable.js
@@ -5,6 +5,7 @@ import axios from "axios";
 import _ from "lodash";
 import Table from "./TableContainerOrden";
 import "../css/tablecamion.css";
+import { getCssVariable } from "../helpers/theme";
 // import { SelectColumnFilter } from "./Filter";
 // import "./App.css";
 function AppOrdenAPrepararReactTable() {
@@ -16,6 +17,11 @@ function AppOrdenAPrepararReactTable() {
       })
       .catch((err) => console.log(err));
   }, []);
+
+  const dangerColor = getCssVariable("--color-status-danger", "#ba1b26");
+  const accentColor = getCssVariable("--color-accent", "#e63946");
+  const contrastText = getCssVariable("--color-text-on-contrast", "#f5f5f5");
+  const infoColor = getCssVariable("--color-status-info", "#548fcd");
 
   // const Styles = styled.div`
   //   padding: 1rem;
@@ -77,20 +83,20 @@ function AppOrdenAPrepararReactTable() {
     sticky: true;
     // background-color: white;
     // background-color: #548fcd;
-    color: black;
+    color: var(--color-text-primary);
     border-spacing: 0;
-    border: 1px solid black;
+    border: 1px solid var(--color-border-strong);
     font-size: 13px;
     z-index: 1;
 
     th {
       sticky: true;
-      background-color: #00ffff;
+      background-color: var(--color-status-highlight);
       font-size: 1.5rem;
       text-align: center;
       height: 4rem;
       // position: sticky;
-      color: black;
+      color: var(--color-text-on-contrast);
       top: 100;
       z-index: 1;
     }
@@ -99,10 +105,10 @@ function AppOrdenAPrepararReactTable() {
       sticky: true;
       margin: 0;
       padding: 0.5rem;
-      border-bottom: 1px solid black;
-      border-right: 1px solid black;
+      border-bottom: 1px solid var(--color-border);
+      border-right: 1px solid var(--color-border);
       // background-color: #548f0a;
-      background-color: #f0f2eb;
+      background-color: var(--color-surface-muted);
       font-size: 13px;
       // top: 100;
       // z-index: 1;
@@ -124,7 +130,8 @@ function AppOrdenAPrepararReactTable() {
 
   .pagination {
     padding: 0.5rem;
-    background-color: #548fcd;
+    background-color: var(--color-status-info);
+    color: var(--color-text-on-contrast);
     font-size: 15px;
     font-weight: bold;
   }
@@ -142,10 +149,10 @@ function AppOrdenAPrepararReactTable() {
     .header {
       font-size: 13px;
       top: 0;
-      box-shadow: 0px 3px 3px #ccc;
+      box-shadow: var(--shadow-soft);
       position: sticky;
       z-index:10;
-      
+
     }
 
     [data-sticky-td] {
@@ -255,42 +262,42 @@ function AppOrdenAPrepararReactTable() {
       style: {
         width: "100px",
         marginRight: "0.5rem",
-        color: "white",
+        color: contrastText,
       },
-      color: "red",
+      color: dangerColor,
       Cell: (row) => <div style={{ textAlign: "center" }}>{row.value}</div>,
     },
 
     {
       Header: "Clientes",
       accessor: "codcli.razonsocial",
-      background: "red",
-      color: "red",
+      background: accentColor,
+      color: dangerColor,
       width: "20em",
       margin: "2em",
     },
     {
       Header: "Ruta",
       accessor: "codcli.ruta.ruta",
-      color: "red",
+      color: dangerColor,
       with: "200rem",
     },
     {
       Header: "Productos",
       accessor: "codprod.descripcion",
-      color: "red",
+      color: dangerColor,
       with: "200rem",
     },
     {
       Header: "Rubro",
       accessor: "codprod.rubro.rubro",
-      color: "red",
+      color: dangerColor,
       with: "200rem",
     },
     {
       Header: "Camion",
       accessor: "camion.camion",
-      color: "red",
+      color: dangerColor,
       with: "200rem",
     },
     {
@@ -302,7 +309,7 @@ function AppOrdenAPrepararReactTable() {
         marginRight: "0.5rem",
         
       },
-      color:"blue",
+      color: infoColor,
       // Cell: (row) => <div style={{ textAlign: "center" }}>{row.value}</div>,
       aggregate: "sum",
       Aggregated: ({ value }) => `${value} Cantidad(es)`,

--- a/front/src/table/AppPreventaReactTable.js
+++ b/front/src/table/AppPreventaReactTable.js
@@ -63,19 +63,20 @@ var iduser = localStorage.getItem("id");
   table {
     sticky: true;
     // background-color: #548fcd;
-    color: black;
+    color: var(--color-text-primary);
     border-spacing: 0;
-    border: 1px solid black;
+    border: 1px solid var(--color-border-strong);
     font-size: 13px;
     z-index: 1;
 
     th {
       sticky: true;
-      background-color: #548fcd;
+      background-color: var(--color-status-info);
       font-size: 12px;
       text-align: center;
       height: 10rem;
       // position: sticky;
+      color: var(--color-text-on-contrast);
       top: 100;
       z-index: 1;
     }
@@ -84,10 +85,10 @@ var iduser = localStorage.getItem("id");
       sticky: true;
       margin: 0;
       padding: 0.5rem;
-      border-bottom: 1px solid black;
-      border-right: 1px solid black;
+      border-bottom: 1px solid var(--color-border);
+      border-right: 1px solid var(--color-border);
       // background-color: #548f0a;
-      background-color: #f0f2eb;
+      background-color: var(--color-surface-muted);
       font-size: 13px;
       // top: 100;
       // z-index: 1;
@@ -109,7 +110,8 @@ var iduser = localStorage.getItem("id");
 
   .pagination {
     padding: 0.5rem;
-    background-color: #548fcd;
+    background-color: var(--color-status-info);
+    color: var(--color-text-on-contrast);
     font-size: 15px;
     font-weight: bold;
   }
@@ -126,10 +128,10 @@ var iduser = localStorage.getItem("id");
     
     .header {
       top: 0;
-      box-shadow: 0px 3px 3px #ccc;
+      box-shadow: var(--shadow-soft);
       position: sticky;
       z-index:10;
-      
+
     }
 
     [data-sticky-td] {

--- a/front/src/table/AppRemitoReactTable.js
+++ b/front/src/table/AppRemitoReactTable.js
@@ -14,6 +14,7 @@ import Table from "./TableContainer";
 import { SelectColumnFilter } from "./Filter";
 import ModalComanda from "../components/ModalComanda";
 // import "../css/tablecomandas.css";
+import { getCssVariable } from "../helpers/theme";
 
 // import "./App.css";
 
@@ -23,6 +24,7 @@ function AppRemitoReactTable() {
     data: {},
     loading: true,
   });
+  const contrastText = getCssVariable("--color-text-on-contrast", "#f5f5f5");
   const [comanda, setComanda] = useState({});
   const [data, setData] = useState([]);
 
@@ -41,19 +43,20 @@ function AppRemitoReactTable() {
   table {
     sticky: true;
     // background-color: #548fcd;
-    color: black;
+    color: var(--color-text-primary);
     border-spacing: 0;
-    border: 1px solid black;
+    border: 1px solid var(--color-border-strong);
     font-size: 13px;
     z-index: 1;
 
     th {
       sticky: true;
-      background-color: #548fcd;
+      background-color: var(--color-status-info);
       font-size: 12px;
       text-align: center;
       height: 10rem;
       // position: sticky;
+      color: var(--color-text-on-contrast);
       top: 100;
       z-index: 1;
     }
@@ -62,10 +65,10 @@ function AppRemitoReactTable() {
       sticky: true;
       margin: 0;
       padding: 0.5rem;
-      border-bottom: 1px solid black;
-      border-right: 1px solid black;
+      border-bottom: 1px solid var(--color-border);
+      border-right: 1px solid var(--color-border);
       // background-color: #548f0a;
-      background-color: #f0f2eb;
+      background-color: var(--color-surface-muted);
       font-size: 13px;
       // top: 100;
       // z-index: 1;
@@ -87,7 +90,8 @@ function AppRemitoReactTable() {
 
   .pagination {
     padding: 0.5rem;
-    background-color: #548fcd;
+    background-color: var(--color-status-info);
+    color: var(--color-text-on-contrast);
     font-size: 15px;
     font-weight: bold;
   }
@@ -104,10 +108,10 @@ function AppRemitoReactTable() {
     
     .header {
       top: 0;
-      box-shadow: 0px 3px 3px #ccc;
+      box-shadow: var(--shadow-soft);
       position: sticky;
       z-index:10;
-      
+
     }
 
     [data-sticky-td] {
@@ -434,7 +438,11 @@ function AppRemitoReactTable() {
             className="btn btn-danger"
             onClick={(e) => deleteRemito(row.row.original.nroderemito)}
           >
-            <i className="fa fa-trash-o" aria-hidden="true" color="white"></i>
+            <i
+              className="fa fa-trash-o"
+              aria-hidden="true"
+              style={{ color: contrastText }}
+            ></i>
           </button>
           {/* <GetDataInvoiceAdmin datacomanda={row.row.original.nrodecomanda} /> */}
         </div>

--- a/front/src/table/TableContainerOrden.js
+++ b/front/src/table/TableContainerOrden.js
@@ -18,9 +18,11 @@ const Styles = styled.div`
   padding: 1rem;
 
   table {
-    margin-top:2px;
+    margin-top: 2px;
     border-spacing: 0;
-    border: 1px solid black;
+    border: 1px solid var(--color-border-strong);
+    background-color: var(--color-surface);
+    color: var(--color-text-primary);
 
     tr {
       :last-child {
@@ -34,8 +36,8 @@ const Styles = styled.div`
     td {
       margin: 0;
       padding: 0.5rem;
-      border-bottom: 1px solid black;
-      border-right: 1px solid black;
+      border-bottom: 1px solid var(--color-border);
+      border-right: 1px solid var(--color-border);
 
       :last-child {
         border-right: 0;
@@ -195,12 +197,13 @@ export default function Table({ columns, data }) {
                       {...cell.getCellProps()}
                       style={{
                         background: cell.isGrouped
-                          ? "white"
+                          ? "var(--color-surface)"
                           : cell.isAggregated
-                          ? "#white"
+                          ? "var(--color-surface)"
                           : cell.isPlaceholder
-                          ? "#white"
-                          : "white",
+                          ? "var(--color-surface)"
+                          : "var(--color-surface)",
+                        color: "var(--color-text-primary)",
                       }}
                     >
                       {cell.isGrouped ? (


### PR DESCRIPTION
## Summary
- add reusable theme CSS variables for light and dark modes and expose helper utilities
- refactor global, component, and table styles to rely on the shared tokens and improve hover/focus feedback
- update table components to consume the theme variables and replace hard-coded colors for consistent accessibility

## Testing
- npm run build *(fails: react-scripts not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfee30ac1c83238d019b9f24dc0428