### PR TITLE
Add theme context provider and update navigation styling

### DIFF
--- a/front/src/Context/ThemeContext.jsx
+++ b/front/src/Context/ThemeContext.jsx
@@ -1,0 +1,66 @@
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+const STORAGE_KEY = "app-theme";
+
+const getPreferredTheme = () => {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  const storedTheme = window.localStorage.getItem(STORAGE_KEY);
+  if (storedTheme === "light" || storedTheme === "dark") {
+    return storedTheme;
+  }
+
+  if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    return "dark";
+  }
+
+  return "light";
+};
+
+export const ThemeContext = createContext({
+  theme: "light",
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(getPreferredTheme);
+
+  useEffect(() => {
+    if (typeof document === "undefined" || typeof window === "undefined") {
+      return;
+    }
+
+    const body = document.body;
+    const root = document.documentElement;
+    const themeClass = theme === "dark" ? "theme-dark" : "theme-light";
+
+    body.classList.remove("theme-light", "theme-dark");
+    body.classList.add(themeClass);
+    root.setAttribute("data-theme", theme);
+
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme,
+    }),
+    [theme, toggleTheme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+

--- a/front/src/css/navbar.css
+++ b/front/src/css/navbar.css
@@ -1,21 +1,21 @@
 .navBar-toggler {
-  color: #f5f5f5 !important;
-  background-color: #121212 !important;
-  border: 1px solid #3a3a3a !important;
+  color: var(--nav-text, #f5f5f5) !important;
+  background-color: var(--nav-surface, #121212) !important;
+  border: 1px solid var(--nav-border, #3a3a3a) !important;
 }
 .navBar h4 {
   font-size: 1.75rem;
   text-align: center;
 
-  background-color: #121212 !important;
-  color: #f5f5f5 !important;
+  background-color: var(--nav-bg, #121212) !important;
+  color: var(--nav-text, #f5f5f5) !important;
   font-family: "Quicksand";
 }
 
 .navBar {
   /* background-color: black !important; */
-  background-color: #121212 !important;
-  color: #f5f5f5 !important;
+  background-color: var(--nav-bg, #121212) !important;
+  color: var(--nav-text, #f5f5f5) !important;
   font-size: 2rem;
   font-family: "Times New Roman", Times, serif;
   padding: 1rem;
@@ -23,13 +23,13 @@
 
 .navBar-toggler:hover,
 .navBar-toggler:focus {
-  color: #e0e0e0 !important;
-  background-color: #1b1b1b !important;
-  border-color: #4a4a4a !important;
+  color: var(--nav-muted-text, #e0e0e0) !important;
+  background-color: var(--nav-hover-bg, #2a2a2a) !important;
+  border-color: var(--nav-focus-border, #4a4a4a) !important;
   outline: none;
 }
 button #hamburguesa.navBar-toggler.collapsed{
-  background: #1b1b1b !important;
+  background: var(--nav-surface, #1b1b1b) !important;
 }
 .nav-link {
   font-family: "Quicksand";
@@ -39,12 +39,12 @@ button #hamburguesa.navBar-toggler.collapsed{
   display: inline;
   text-align: center;
   /* -webkit-margin-start: 2rem; */
-  color: #f5f5f5 !important;
+  color: var(--nav-text, #f5f5f5) !important;
 }
 .nav-link:hover,
 .nav-link:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: var(--nav-muted-text, #e0e0e0) !important;
+  background-color: var(--nav-hover-bg, #2a2a2a) !important;
   outline: none;
 }
 
@@ -57,7 +57,7 @@ button #hamburguesa.navBar-toggler.collapsed{
   text-align: center;
   -webkit-margin-start: 1rem;
   -webkit-margin-end: 1rem;
-  color: #f5f5f5 !important;
+  color: var(--nav-text, #f5f5f5) !important;
   display: flex;
   justify-content: center;
   margin-top: 0.5rem;
@@ -67,27 +67,27 @@ button #hamburguesa.navBar-toggler.collapsed{
   font-family: "Quicksand";
   font-size: 1.5rem;
   /* background-color: black !important; */
-  background-color: #1b1b1b !important;
-  color: #f5f5f5 !important;
-  border: 1px solid #3a3a3a !important;
+  background-color: var(--nav-dropdown-bg, #1b1b1b) !important;
+  color: var(--nav-dropdown-text, #f5f5f5) !important;
+  border: 1px solid var(--nav-dropdown-border, #3a3a3a) !important;
 }
 
 .dropdown-item {
   font-family: "Quicksand";
   font-size: 1.5rem;
   /* background-color: black !important; */
-  background-color: #1b1b1b !important;
-  color: #f5f5f5 !important;
+  background-color: var(--nav-dropdown-bg, #1b1b1b) !important;
+  color: var(--nav-dropdown-text, #f5f5f5) !important;
 }
 .dropdown-item:hover,
 .dropdown-item:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: var(--nav-muted-text, #e0e0e0) !important;
+  background-color: var(--nav-hover-bg, #2a2a2a) !important;
 }
 
 .nav-link1 {
   font-family: "Quicksand";
-  color: #f5f5f5 !important;
+  color: var(--nav-text, #f5f5f5) !important;
   margin-bottom: 10px;
   font-size: 1.75rem;
   display: inline;
@@ -97,14 +97,14 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 .nav-link1:hover,
 .nav-link1:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: var(--nav-muted-text, #e0e0e0) !important;
+  background-color: var(--nav-hover-bg, #2a2a2a) !important;
   outline: none;
 }
 
 .nav-link3 {
   font-family: "Quicksand";
-  color: #f5f5f5 !important;
+  color: var(--nav-text, #f5f5f5) !important;
   margin-bottom: 10px;
   font-size: 1.75rem;
   display: inline;
@@ -114,14 +114,14 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 .nav-link3:hover,
 .nav-link3:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: var(--nav-muted-text, #e0e0e0) !important;
+  background-color: var(--nav-hover-bg, #2a2a2a) !important;
   outline: none;
 }
 
 .nav-link2 {
   font-family: "Quicksand";
-  color: #f5f5f5 !important;
+  color: var(--nav-text, #f5f5f5) !important;
   margin-bottom: 10px;
   font-size: 1.75rem;
   display: inline;
@@ -133,18 +133,18 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 .nav-link2:hover,
 .nav-link2:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  color: var(--nav-muted-text, #e0e0e0) !important;
+  background-color: var(--nav-hover-bg, #2a2a2a) !important;
   outline: none;
 }
 
 #navBar nav {
-  background-color: #121212 !important;
+  background-color: var(--nav-bg, #121212) !important;
   /* background-color: black !important; */
   font-size: 1.75rem;
   display: flex;
   justify-content: center;
-  color: #f5f5f5 !important;
+  color: var(--nav-text, #f5f5f5) !important;
 }
 
 .navBar img {
@@ -152,39 +152,39 @@ button #hamburguesa.navBar-toggler.collapsed{
   padding: 1rem;
   display: flex;
   justify-content: center;
-  color: #f5f5f5 !important;
+  color: var(--nav-text, #f5f5f5) !important;
 }
 
 .navBar span {
-  background-color: #121212 !important;
+  background-color: var(--nav-bg, #121212) !important;
   /* background-color: black !important; */
   font-size: 2.2rem;
-  color: #f5f5f5 !important;
+  color: var(--nav-text, #f5f5f5) !important;
   font-family: "Times New Roman", Times, serif;
 }
 
 #booton {
   font-family: "Quicksand";
   font-size: 1.75rem;
-  color: #f5f5f5 !important;
-  background-color: #1b1b1b !important;
-  border: 1px solid #3a3a3a !important;
+  color: var(--nav-button-text, #f5f5f5) !important;
+  background-color: var(--nav-button-bg, #1b1b1b) !important;
+  border: 1px solid var(--nav-border, #3a3a3a) !important;
 }
 #booton:hover,
 #booton:focus {
-  color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
-  border-color: #4a4a4a !important;
+  color: var(--nav-muted-text, #e0e0e0) !important;
+  background-color: var(--nav-hover-bg, #2a2a2a) !important;
+  border-color: var(--nav-focus-border, #4a4a4a) !important;
   outline: none;
 }
 
 #user {
   font-family: "Quicksand";
   font-size: 1.75rem;
-  color: #e0e0e0 !important;
+  color: var(--nav-muted-text, #e0e0e0) !important;
 }
 #user:focus {
-  outline: 2px solid #4a4a4a;
+  outline: 2px solid var(--nav-focus-border, #4a4a4a);
   outline-offset: 2px;
 }
 

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -1,9 +1,71 @@
 html {
-    font-size: 62.5%;
-  }
-  
-  body #root {
-    font-family: "Quicksand";
-    background-color: #f1faee;
-  }
-  
+  font-size: 62.5%;
+}
+
+body {
+  font-family: "Quicksand";
+  background-color: var(--body-bg, #f1faee);
+  color: var(--body-text, #1d3557);
+  margin: 0;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+body #root {
+  min-height: 100vh;
+  background-color: inherit;
+  color: inherit;
+}
+
+body.theme-light {
+  color-scheme: light;
+  --body-bg: #f1faee;
+  --body-text: #1d3557;
+  --nav-bg: #ffffff;
+  --nav-surface: #f8f9fa;
+  --nav-border: #d1d5db;
+  --nav-text: #1f2937;
+  --nav-muted-text: #111827;
+  --nav-hover-bg: #e5e7eb;
+  --nav-focus-border: #9ca3af;
+  --nav-button-bg: #ffffff;
+  --nav-button-text: #1f2937;
+  --nav-dropdown-bg: #ffffff;
+  --nav-dropdown-border: #d1d5db;
+  --nav-dropdown-text: #1f2937;
+}
+
+body.theme-dark {
+  color-scheme: dark;
+  --body-bg: #0f0f0f;
+  --body-text: #f5f5f5;
+  --nav-bg: #121212;
+  --nav-surface: #1b1b1b;
+  --nav-border: #3a3a3a;
+  --nav-text: #f5f5f5;
+  --nav-muted-text: #e0e0e0;
+  --nav-hover-bg: #2a2a2a;
+  --nav-focus-border: #4a4a4a;
+  --nav-button-bg: #1b1b1b;
+  --nav-button-text: #f5f5f5;
+  --nav-dropdown-bg: #1b1b1b;
+  --nav-dropdown-border: #3a3a3a;
+  --nav-dropdown-text: #f5f5f5;
+}
+
+/* Provide sensible defaults before the ThemeProvider runs */
+body {
+  --body-bg: #f1faee;
+  --body-text: #1d3557;
+  --nav-bg: #121212;
+  --nav-surface: #1b1b1b;
+  --nav-border: #3a3a3a;
+  --nav-text: #f5f5f5;
+  --nav-muted-text: #e0e0e0;
+  --nav-hover-bg: #2a2a2a;
+  --nav-focus-border: #4a4a4a;
+  --nav-button-bg: #1b1b1b;
+  --nav-button-text: #f5f5f5;
+  --nav-dropdown-bg: #1b1b1b;
+  --nav-dropdown-border: #3a3a3a;
+  --nav-dropdown-text: #f5f5f5;
+}

--- a/front/src/index.js
+++ b/front/src/index.js
@@ -5,6 +5,7 @@ import 'bootstrap/dist/css/bootstrap.css'
 import './index.css';
 import App from './App';
 import Applogin from './Applogin';
+import { ThemeProvider } from './Context/ThemeContext';
 
 // import server from './server';
 
@@ -22,8 +23,10 @@ import Applogin from './Applogin';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
-    {/* <Applogin /> */}
+    <ThemeProvider>
+      <App />
+      {/* <Applogin /> */}
+    </ThemeProvider>
   </React.StrictMode>,
   document.getElementById('root')
 );


### PR DESCRIPTION
## Summary
- add a reusable ThemeContext and provider that stores and toggles the active theme
- wrap the React entry point with the ThemeProvider so components can consume the theme context
- define theme-aware CSS variables and update navigation styles to react to theme changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dff6d257ec8323a6138348d60ae285