### PR TITLE
Add theme context provider to share global theme state

### DIFF
--- a/front/src/Context/ThemeContext.jsx
+++ b/front/src/Context/ThemeContext.jsx
@@ -1,0 +1,64 @@
+import React, { createContext, useEffect, useMemo, useState } from "react";
+
+const DEFAULT_THEME = "light";
+const THEME_CLASSES = {
+  light: "theme-light",
+  dark: "theme-dark",
+};
+
+const ThemeContext = createContext({
+  theme: DEFAULT_THEME,
+  toggleTheme: () => {},
+});
+
+const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(() => {
+    if (typeof window === "undefined") {
+      return DEFAULT_THEME;
+    }
+
+    const storedTheme = window.localStorage.getItem("app-theme");
+    return storedTheme && Object.keys(THEME_CLASSES).includes(storedTheme)
+      ? storedTheme
+      : DEFAULT_THEME;
+  });
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const bodyClassList = document.body.classList;
+    const themeClass = THEME_CLASSES[theme] || THEME_CLASSES[DEFAULT_THEME];
+
+    Object.values(THEME_CLASSES).forEach((className) => {
+      if (className) {
+        bodyClassList.remove(className);
+      }
+    });
+
+    if (themeClass) {
+      bodyClassList.add(themeClass);
+    }
+
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("app-theme", theme);
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prevTheme) => (prevTheme === "light" ? "dark" : "light"));
+  };
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme,
+    }),
+    [theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export { ThemeContext, ThemeProvider };

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -1,9 +1,22 @@
 html {
     font-size: 62.5%;
   }
-  
-  body #root {
+
+  body {
     font-family: "Quicksand";
-    background-color: #f1faee;
+    transition: background-color 0.3s ease, color 0.3s ease;
   }
-  
+
+  body #root {
+    min-height: 100vh;
+  }
+
+  body.theme-light {
+    background-color: #f1faee;
+    color: #1d3557;
+  }
+
+  body.theme-dark {
+    background-color: #1d1d1f;
+    color: #f5f5f7;
+  }

--- a/front/src/index.js
+++ b/front/src/index.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import 'bootstrap/dist/css/bootstrap.css'
 import './index.css';
 import App from './App';
+import { ThemeProvider } from './Context/ThemeContext';
 import Applogin from './Applogin';
 
 // import server from './server';
@@ -22,7 +23,9 @@ import Applogin from './Applogin';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
     {/* <Applogin /> */}
   </React.StrictMode>,
   document.getElementById('root')


### PR DESCRIPTION
## Summary
- create a ThemeContext provider that stores the current theme and toggling function while updating global body classes
- wrap the application entry point with the new ThemeProvider so all components can consume the theme context
- define light and dark theme body styles to respond to context changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e002703a00832385471130ba7d9f5f