### PR TITLE
Add theme toggle button to navbar

### DIFF
--- a/front/src/Context/ThemeContext.jsx
+++ b/front/src/Context/ThemeContext.jsx
@@ -1,0 +1,53 @@
+import React, { createContext, useCallback, useEffect, useMemo, useState } from "react";
+
+const defaultTheme = "light";
+
+const ThemeContext = createContext({
+  theme: defaultTheme,
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(() => {
+    if (typeof window === "undefined") {
+      return defaultTheme;
+    }
+
+    const storedTheme = window.localStorage.getItem("theme");
+    return storedTheme === "light" || storedTheme === "dark"
+      ? storedTheme
+      : defaultTheme;
+  });
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      document.body.classList.remove("light-theme", "dark-theme");
+      document.body.classList.add(`${theme}-theme`);
+    }
+
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("theme", theme);
+    }
+    return () => {
+      if (typeof document !== "undefined") {
+        document.body.classList.remove(`${theme}-theme`);
+      }
+    };
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prevTheme) => (prevTheme === "light" ? "dark" : "light"));
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme,
+    }),
+    [theme, toggleTheme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export default ThemeContext;

--- a/front/src/components/NavBar.jsx
+++ b/front/src/components/NavBar.jsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import jwt_decode from "jwt-decode"; //Paquete para decodificar el Token
 import { Link, useLocation, useHistory } from "react-router-dom";
 // import { getComandas } from "../helpers/rutaComandas";
 import { Navbar, Nav, NavDropdown } from "react-bootstrap";
 import logo from "../images/distripollo.jpeg";
 import "../css/navbar.css";
+import ThemeContext from "../Context/ThemeContext";
 
 const NavBar = () => {
   //Defino location e history
@@ -13,6 +14,8 @@ const NavBar = () => {
 
   //estado para manejar el usuario
   const [user, setUser] = useState("Iniciar sesión");
+
+  const { theme, toggleTheme } = useContext(ThemeContext);
 
   const [payload, setPayload] = useState({
     role: "",
@@ -395,22 +398,31 @@ const NavBar = () => {
                 </Link>
               )}
             </Nav>
-            {payload.role === "ADMIN_ROLE" && (
-              <Link
-                to="/admin"
-                id="user"
-                className="text-decoration-none text-muted ml-5 mr-3 "
+            <div className="ml-auto d-flex align-items-center">
+              {payload.role === "ADMIN_ROLE" && (
+                <Link
+                  to="/admin"
+                  id="user"
+                  className="text-decoration-none text-muted ml-5 mr-3 "
+                >
+                  Administrador
+                </Link>
+              )}
+              <button
+                type="button"
+                className="btn btn-outline-secondary ml-3 theme-toggle-btn"
+                onClick={toggleTheme}
               >
-                Administrador
-              </Link>
-            )}
-            <button
-              id="booton"
-              className="btn btn-outline-info"
-              onClick={handleLogin}
-            >
-              {user}
-            </button>
+                {theme === "light" ? "Modo claro" : "Modo oscuro"}
+              </button>
+              <button
+                id="booton"
+                className="btn btn-outline-info ml-3"
+                onClick={handleLogin}
+              >
+                {user}
+              </button>
+            </div>
      
           </Navbar.Collapse>
         </Navbar>

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -1,9 +1,65 @@
 html {
-    font-size: 62.5%;
-  }
-  
-  body #root {
-    font-family: "Quicksand";
-    background-color: #f1faee;
-  }
+  font-size: 62.5%;
+}
+
+body {
+  margin: 0;
+  font-family: "Quicksand";
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+body #root {
+  min-height: 100vh;
+  transition: inherit;
+}
+
+body.light-theme,
+body.light-theme #root {
+  background-color: #f1faee;
+  color: #1d3557;
+}
+
+body.dark-theme,
+body.dark-theme #root {
+  background-color: #1d3557;
+  color: #f1faee;
+}
+
+.theme-toggle-btn {
+  min-width: 12rem;
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+body.dark-theme .theme-toggle-btn {
+  color: #f1faee;
+  border-color: rgba(241, 250, 238, 0.6);
+}
+
+body.dark-theme .theme-toggle-btn:hover,
+body.dark-theme .theme-toggle-btn:focus {
+  background-color: rgba(241, 250, 238, 0.15);
+  color: #f1faee;
+}
+
+body.dark-theme .navbar-light {
+  background-color: #22344d !important;
+}
+
+body.dark-theme .navbar-light .navbar-brand,
+body.dark-theme .navbar-light .navbar-nav .nav-link,
+body.dark-theme .navbar-light .navbar-text,
+body.dark-theme .navbar-light .navbar-toggler {
+  color: #f1faee;
+}
+
+body.dark-theme .navbar-light .navbar-nav .nav-link:hover,
+body.dark-theme .navbar-light .navbar-nav .nav-link:focus,
+body.dark-theme .navbar-light .navbar-brand:hover,
+body.dark-theme .navbar-light .navbar-brand:focus {
+  color: #a8dadc;
+}
+
+body.dark-theme .navbar-light .navbar-toggler-icon {
+  filter: invert(1);
+}
   

--- a/front/src/index.js
+++ b/front/src/index.js
@@ -5,6 +5,7 @@ import 'bootstrap/dist/css/bootstrap.css'
 import './index.css';
 import App from './App';
 import Applogin from './Applogin';
+import { ThemeProvider } from './Context/ThemeContext';
 
 // import server from './server';
 
@@ -22,7 +23,9 @@ import Applogin from './Applogin';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
     {/* <Applogin /> */}
   </React.StrictMode>,
   document.getElementById('root')


### PR DESCRIPTION
## Summary
- add a ThemeContext provider with persistent light/dark mode handling
- expose a theme toggle button in the navbar that reflects the current mode
- update global styles so the layout and navbar respond to the active theme

## Testing
- NODE_OPTIONS=--openssl-legacy-provider npm start -- --host 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68e005caebac83239495dd03e1c517fd