### PR TITLE
Adjust navbar dark mode to absolute black

### DIFF
--- a/front/src/css/navbar.css
+++ b/front/src/css/navbar.css
@@ -1,20 +1,20 @@
 .navBar-toggler {
   color: #f5f5f5 !important;
-  background-color: #121212 !important;
+  background-color: #000000 !important;
   border: 1px solid #3a3a3a !important;
 }
 .navBar h4 {
   font-size: 1.75rem;
   text-align: center;
 
-  background-color: #121212 !important;
+  background-color: #000000 !important;
   color: #f5f5f5 !important;
   font-family: "Quicksand";
 }
 
 .navBar {
   /* background-color: black !important; */
-  background-color: #121212 !important;
+  background-color: #000000 !important;
   color: #f5f5f5 !important;
   font-size: 2rem;
   font-family: "Times New Roman", Times, serif;
@@ -24,12 +24,12 @@
 .navBar-toggler:hover,
 .navBar-toggler:focus {
   color: #e0e0e0 !important;
-  background-color: #1b1b1b !important;
+  background-color: rgba(0, 0, 0, 0.85) !important;
   border-color: #4a4a4a !important;
   outline: none;
 }
 button #hamburguesa.navBar-toggler.collapsed{
-  background: #1b1b1b !important;
+  background: #000000 !important;
 }
 .nav-link {
   font-family: "Quicksand";
@@ -44,7 +44,7 @@ button #hamburguesa.navBar-toggler.collapsed{
 .nav-link:hover,
 .nav-link:focus {
   color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  background-color: rgba(0, 0, 0, 0.85) !important;
   outline: none;
 }
 
@@ -67,7 +67,7 @@ button #hamburguesa.navBar-toggler.collapsed{
   font-family: "Quicksand";
   font-size: 1.5rem;
   /* background-color: black !important; */
-  background-color: #1b1b1b !important;
+  background-color: #000000 !important;
   color: #f5f5f5 !important;
   border: 1px solid #3a3a3a !important;
 }
@@ -76,13 +76,13 @@ button #hamburguesa.navBar-toggler.collapsed{
   font-family: "Quicksand";
   font-size: 1.5rem;
   /* background-color: black !important; */
-  background-color: #1b1b1b !important;
+  background-color: #000000 !important;
   color: #f5f5f5 !important;
 }
 .dropdown-item:hover,
 .dropdown-item:focus {
   color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  background-color: rgba(0, 0, 0, 0.85) !important;
 }
 
 .nav-link1 {
@@ -98,7 +98,7 @@ button #hamburguesa.navBar-toggler.collapsed{
 .nav-link1:hover,
 .nav-link1:focus {
   color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  background-color: rgba(0, 0, 0, 0.85) !important;
   outline: none;
 }
 
@@ -115,7 +115,7 @@ button #hamburguesa.navBar-toggler.collapsed{
 .nav-link3:hover,
 .nav-link3:focus {
   color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  background-color: rgba(0, 0, 0, 0.85) !important;
   outline: none;
 }
 
@@ -134,12 +134,12 @@ button #hamburguesa.navBar-toggler.collapsed{
 .nav-link2:hover,
 .nav-link2:focus {
   color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  background-color: rgba(0, 0, 0, 0.85) !important;
   outline: none;
 }
 
 #navBar nav {
-  background-color: #121212 !important;
+  background-color: #000000 !important;
   /* background-color: black !important; */
   font-size: 1.75rem;
   display: flex;
@@ -156,7 +156,7 @@ button #hamburguesa.navBar-toggler.collapsed{
 }
 
 .navBar span {
-  background-color: #121212 !important;
+  background-color: #000000 !important;
   /* background-color: black !important; */
   font-size: 2.2rem;
   color: #f5f5f5 !important;
@@ -167,13 +167,13 @@ button #hamburguesa.navBar-toggler.collapsed{
   font-family: "Quicksand";
   font-size: 1.75rem;
   color: #f5f5f5 !important;
-  background-color: #1b1b1b !important;
+  background-color: #000000 !important;
   border: 1px solid #3a3a3a !important;
 }
 #booton:hover,
 #booton:focus {
   color: #e0e0e0 !important;
-  background-color: #2a2a2a !important;
+  background-color: rgba(0, 0, 0, 0.85) !important;
   border-color: #4a4a4a !important;
   outline: none;
 }


### PR DESCRIPTION
## Summary
- replace the navbar, toggler, dropdown, and button backgrounds with pure black to achieve an absolute black dark mode
- update hover and focus states to use translucent black while preserving contrast with light text

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e038dfbd94832384466a70d3ef07cd